### PR TITLE
fix: fix compile error and segfault

### DIFF
--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -21,7 +21,6 @@ Client::~Client(void) {
   std ::cout << " Client destructor called " << this->getSD() << " !"
              << std::endl;
 #endif
-  if (this->_method != NULL) delete this->_method;
 }
 
 bool Client::checkIfReceiveFinished(ssize_t n) {

--- a/srcs/clients/method/include/AMethod.hpp
+++ b/srcs/clients/method/include/AMethod.hpp
@@ -31,6 +31,7 @@ class AMethod {
   void parseRequestLine(void);
   void parseHeaderFields(void);
 
+  std::string getFirstTokenOfPath(void) const;
   bool checkBodyExistance(std::list<std::string>::const_iterator it) const;
   bool checkPathForm();
   void setDefaultLocation(

--- a/srcs/config/child_config/location_config/src/LocationConfig.cpp
+++ b/srcs/config/child_config/location_config/src/LocationConfig.cpp
@@ -1,6 +1,6 @@
 #include "../include/LocationConfig.hpp"
 
-const std::string LocationConfig::DEFAULT_ROUTE = "";
+const std::string LocationConfig::DEFAULT_ROUTE = "/";
 const std::string LocationConfig::DEFAULT_ROOT = "/YoupiBanane/";
 const std::string LocationConfig::DEFAULT_ALLOW_METHOD = "";
 const std::string LocationConfig::DEFAULT_INDEX = "";

--- a/srcs/server/src/Server.cpp
+++ b/srcs/server/src/Server.cpp
@@ -60,7 +60,7 @@ void Server::hostInit(void) {
   std::list<IServerConfig *> serverInfo = config.getServerConfigs();
   std::list<IServerConfig *>::iterator it = serverInfo.begin();
   while (it != serverInfo.end()) {
-    if ((*it)->getListen() == (size_t)this->_port) {
+    if ((*it)->getListen() == this->_port) {
       this->_host = (*it)->getServerName();
       return;
     } else {


### PR DESCRIPTION
- Client 클래스 소멸자 내부에 있는 불필요한 delete를 삭제하였습니다.
- 요청 라인의 path에서 route를 찾아 해당 location 블록의 root로 대치하는 로직을 refactor 하였습니다.
- LocationConfig의  default route를 '/'로 변경하여 segfault를 막았습니다.
- getListen() 함수의 리턴값 변경에 따른 불필요한 형변환을 제거하였습니다.