### PR TITLE
perf(EventHandler): move client into udata

### DIFF
--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -53,7 +53,7 @@ class Client {
   AMethod *getMethod() const;
   void receiveRequest();
   void newHTTPMethod();
-  void sendResponse(std::map<int, Client> &_clients);
+  void sendResponse();
   void setFlag(ClientFlag flag);
   ClientFlag getFlag() const;
   class RecvFailException : public std::exception {

--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -53,13 +53,10 @@ void Client::receiveRequest(void) {
   }
 }
 
-void Client::sendResponse(std::map<int, Client> &clients) {
+void Client::sendResponse() {
   if (this->_flag != REQUEST_DONE) return;
-  if (clients.empty()) return;
   signal(SIGPIPE, SIG_DFL);
-  std::map<int, Client>::iterator it = clients.find(this->_sd);
-  if (it != clients.end() && this->_method != NULL &&
-      this->_method->getResponseFlag() == true) {
+  if (this->_method != NULL && this->_method->getResponseFlag() == true) {
     const std::string &response = this->_method->getResponse();
     ssize_t n = send(this->_sd, response.c_str(), response.size(), 0);
     if (n <= 0) {

--- a/srcs/server/include/EventHandler.hpp
+++ b/srcs/server/include/EventHandler.hpp
@@ -25,21 +25,23 @@ class Client;
 
 class EventHandler : public Kqueue {
  private:
-  std::map<int, Client> _clients;
   std::set<uintptr_t> _serverSocketSet;
   struct kevent* _currentEvent;
+  bool _errorFlag;
 
-  void registClient(const uintptr_t clientSocket);
+  void checkErrorOnSocket(void);
   void acceptClient(void);
-  void branchCondition(void);
+  void registClient(const uintptr_t clientSocket);
+  void processRequest(Client& client);
+  void processResponse(Client& client);
 
  public:
   EventHandler(const std::vector<Server*>& serverVector);
   virtual ~EventHandler();
 
   void setCurrentEvent(int i);
-  void checkStatus(void);
-  void checkErrorOnSocketVector(void);
+  void checkFlags(void);
+  void branchCondition(void);
 };
 
 #endif

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -1,6 +1,7 @@
 #include "EventHandler.hpp"
 
-EventHandler::EventHandler(const std::vector<Server *> &serverVector) {
+EventHandler::EventHandler(const std::vector<Server *> &serverVector)
+    : _errorFlag(false) {
   for (std::vector<Server *>::const_iterator it = serverVector.begin();
        it != serverVector.end(); ++it) {
     this->_serverSocketSet.insert((*it)->getSocket());
@@ -10,21 +11,20 @@ EventHandler::EventHandler(const std::vector<Server *> &serverVector) {
 
 EventHandler::~EventHandler(void) {}
 
-void EventHandler::checkStatus(void) {
-  if (_currentEvent->flags & EV_ERROR)
-    checkErrorOnSocketVector();
-  else
-    branchCondition();
+void EventHandler::checkFlags(void) {
+  this->_errorFlag = false;
+  if (_currentEvent->flags & EV_ERROR) {
+    this->_errorFlag = true;
+    checkErrorOnSocket();
+  }
 }
 
-void EventHandler::checkErrorOnSocketVector() {
+void EventHandler::checkErrorOnSocket() {
   if (_serverSocketSet.find(this->_currentEvent->ident) !=
       this->_serverSocketSet.end())
     throwWithPerror("server socket error");
-  else {
-    std::cout << " client socket error" << std::endl;
-    disconnectClient(_currentEvent->ident, this->_clients);
-  }
+  std::cout << " client socket error" << std::endl;
+  disconnectClient(static_cast<Client *>(this->_currentEvent->udata));
 }
 
 void EventHandler::setCurrentEvent(int i) {
@@ -32,38 +32,46 @@ void EventHandler::setCurrentEvent(int i) {
 }
 
 void EventHandler::branchCondition(void) {
+  if (this->_errorFlag == true) return;
+  if (_serverSocketSet.find(this->_currentEvent->ident) !=
+      this->_serverSocketSet.end()) {
+    acceptClient();
+    return;
+  }
+  Client &currClient = *(static_cast<Client *>(this->_currentEvent->udata));
   if (this->_currentEvent->filter == EVFILT_READ) {
-    if (_serverSocketSet.find(this->_currentEvent->ident) !=
-        this->_serverSocketSet.end())
-      acceptClient();
-    else if (this->_clients.find(this->_currentEvent->ident) !=
-             this->_clients.end()) {
-      Client &currClient = this->_clients[this->_currentEvent->ident];
-      try {
-        std::cout << "socket descriptor : " << currClient.getSD() << std::endl;
-        currClient.receiveRequest();
-        currClient.newHTTPMethod();
-        currClient.getMethod()->parseRequest();
-        currClient.getMethod()->matchServerConf(getBoundPort(_currentEvent));
-        currClient.getMethod()->validatePath();
-        currClient.getMethod()->doRequest();
-        currClient.getMethod()->createSuccessResponse();
-      } catch (enum Status &code) {
-        currClient.getMethod()->createErrorResponse();
-      } catch (std::exception &e) {
-        disconnectClient(this->_currentEvent->ident, this->_clients);
-        std::cerr << e.what() << '\n';
-      };
-    }
-  } else if (this->_currentEvent->filter == EVFILT_WRITE) {
-    try {
-      this->_clients[this->_currentEvent->ident].sendResponse(this->_clients);
-    } catch (std::exception &e) {
-      std::cerr << e.what() << '\n';
-    };
-    if (this->_clients[this->_currentEvent->ident].getFlag() == END) {
-      disconnectClient(this->_currentEvent->ident, this->_clients);
-    }
+    processRequest(currClient);
+    return;
+  }
+  processResponse(currClient);
+}
+
+void EventHandler::processRequest(Client &currClient) {
+  try {
+    std::cout << "socket descriptor : " << currClient.getSD() << std::endl;
+    currClient.receiveRequest();
+    currClient.newHTTPMethod();
+    currClient.getMethod()->parseRequest();
+    currClient.getMethod()->matchServerConf(getBoundPort(_currentEvent));
+    currClient.getMethod()->validatePath();
+    currClient.getMethod()->doRequest();
+    currClient.getMethod()->createSuccessResponse();
+  } catch (enum Status &code) {
+    currClient.getMethod()->createErrorResponse();
+  } catch (std::exception &e) {
+    disconnectClient(&currClient);
+    std::cerr << e.what() << '\n';
+  };
+}
+
+void EventHandler::processResponse(Client &currClient) {
+  try {
+    currClient.sendResponse();
+  } catch (std::exception &e) {
+    std::cerr << e.what() << '\n';
+  };
+  if (currClient.getFlag() == END) {
+    disconnectClient(&currClient);
   }
 }
 
@@ -77,8 +85,9 @@ void EventHandler::acceptClient() {
 }
 
 void EventHandler::registClient(const uintptr_t clientSocket) {
-  addEvent(clientSocket, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
-  addEvent(clientSocket, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, NULL);
-
-  _clients.insert(std::pair<int, Client>(clientSocket, Client(clientSocket)));
+  Client *newClient = new Client(clientSocket);
+  addEvent(clientSocket, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
+           static_cast<void *>(newClient));
+  addEvent(clientSocket, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
+           static_cast<void *>(newClient));
 }

--- a/srcs/server/src/ServerManager.cpp
+++ b/srcs/server/src/ServerManager.cpp
@@ -53,7 +53,8 @@ void ServerManager::startServer(void) {
       int eventCount = _eventQueue.newEvents();
       for (int i = 0; i < eventCount; ++i) {
         eventHandler.setCurrentEvent(i);
-        eventHandler.checkStatus();
+        eventHandler.checkFlags();
+        eventHandler.branchCondition();
       }
     }
   } catch (std::exception &e) {

--- a/srcs/utils/util/include/Utils.hpp
+++ b/srcs/utils/util/include/Utils.hpp
@@ -10,7 +10,7 @@
 #include "Client.hpp"
 
 void throwWithPerror(const std::string &msg);
-void disconnectClient(int client_fd, std::map<int, Client> &clients);
+void disconnectClient(const Client *client);
 short getBoundPort(const struct kevent *_currentEvent);
 std::string getCurrentTime();
 std::string itos(int num);

--- a/srcs/utils/util/src/Utils.cpp
+++ b/srcs/utils/util/src/Utils.cpp
@@ -14,19 +14,13 @@ void throwWithPerror(const std::string &msg) {
   throw(EXIT_FAILURE);
 }
 
-void disconnectClient(int client_fd, std::map<int, Client> &clients) {
-  std::map<int, Client>::iterator it = clients.find(client_fd);
-  if (it == clients.end()) {
-    std::cerr << "Client " << client_fd << " not found!" << std::endl;
-    return;
-  }
-  Kqueue::deleteEvent((uintptr_t)client_fd, EVFILT_WRITE);
-  Kqueue::deleteEvent((uintptr_t)client_fd, EVFILT_READ);
-  close(client_fd);
-  if (clients[client_fd].getMethod() != NULL)
-    delete clients[client_fd].getMethod();
-  clients.erase(client_fd);
-  std::cout << "Client " << client_fd << "disconnected!" << std::endl;
+void disconnectClient(const Client *client) {
+  Kqueue::deleteEvent((uintptr_t)client->getSD(), EVFILT_WRITE);
+  Kqueue::deleteEvent((uintptr_t)client->getSD(), EVFILT_READ);
+  close(client->getSD());
+  if (client->getMethod() != NULL) delete client->getMethod();
+  std::cout << "Client " << client->getSD() << " disconnected!" << std::endl;
+  delete client;
 }
 
 short getBoundPort(const struct kevent *_currentEvent) {


### PR DESCRIPTION
- EventHandler의 std::map _clients 멤버 변수를 삭제하여 매번 맵에서 원하는 fd에 매칭하는 클라이언트 객체를 탐색하는 대신, accept 시 생성한 클라이언트 객체를 kevent 구조체의 void *udata에 할당하여 kevent() 호출을 통해 해당 클라이언트 객체에 바로 접근할 수 있도록 변경하였습니다.
- 이외에 멤버 함수 branchCondition 내부의 if-elseif 문을 삭제하고 원하는 동작이 이루어지면 즉각 리턴되도록 변경하였습니다.