### PR TITLE
43 response request 분리

### DIFF
--- a/srcs/clients/candidate_fields/include/CandidateFields.hpp
+++ b/srcs/clients/candidate_fields/include/CandidateFields.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <set>
+#include <string>
+
+#include "ICandidateFields.hpp"
+
+class CandidateFields : public ICandidateFields {
+ private:
+  CandidateFields();
+  CandidateFields(const CandidateFields& src);
+  CandidateFields& operator=(const CandidateFields& src);
+  ~CandidateFields();
+
+  void initCandidateFields();
+
+ private:
+  std::set<std::string> _candidateFields;
+
+ public:
+  static CandidateFields& getInstance();
+  const std::set<std::string>& getCandidateFields();
+};

--- a/srcs/clients/candidate_fields/include/ICandidateFields.hpp
+++ b/srcs/clients/candidate_fields/include/ICandidateFields.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <set>
+#include <string>
+
+class ICandidateFields {
+ public:
+  virtual const std::set<std::string>& getCandidateFields() = 0;
+
+  virtual ~ICandidateFields() {}
+};

--- a/srcs/clients/candidate_fields/srcs/CandidateFields.cpp
+++ b/srcs/clients/candidate_fields/srcs/CandidateFields.cpp
@@ -1,0 +1,73 @@
+#include "CandidateFields.hpp"
+
+CandidateFields::CandidateFields() { initCandidateFields(); }
+
+CandidateFields::CandidateFields(const CandidateFields& src) { *this = src; }
+
+CandidateFields& CandidateFields::operator=(const CandidateFields& src) {
+  if (this != &src) {
+    _candidateFields = src._candidateFields;
+  }
+  return *this;
+}
+
+CandidateFields::~CandidateFields() {}
+
+void CandidateFields::initCandidateFields() {
+  _candidateFields.insert("host");
+  _candidateFields.insert("accept");
+  _candidateFields.insert("accept-language");
+  _candidateFields.insert("accept-encoding");
+  _candidateFields.insert("accept-charset");
+  _candidateFields.insert("authorization");
+  _candidateFields.insert("content-type");
+  _candidateFields.insert("connection");
+  _candidateFields.insert("user-agent");
+  _candidateFields.insert("content-length");
+  _candidateFields.insert("content-language");
+  _candidateFields.insert("content-encoding");
+  _candidateFields.insert("content-range");
+  _candidateFields.insert("content-length");
+  _candidateFields.insert("content-base");
+  _candidateFields.insert("content-location");
+  _candidateFields.insert("content-range");
+  _candidateFields.insert("keep-alive");
+  _candidateFields.insert("referer");
+  _candidateFields.insert("cookie");
+  _candidateFields.insert("last-modified");
+  _candidateFields.insert("if-modified-since");
+  _candidateFields.insert("date");
+  _candidateFields.insert("server");
+  _candidateFields.insert("www-authenticate");
+  _candidateFields.insert("retry-after");
+  _candidateFields.insert("location");
+  _candidateFields.insert("content-md5");
+  _candidateFields.insert("cache-control");
+  _candidateFields.insert("pragma");
+  _candidateFields.insert("expires");
+  _candidateFields.insert("age");
+  _candidateFields.insert("allow");
+  _candidateFields.insert("etag");
+  _candidateFields.insert("accept-ranges");
+  _candidateFields.insert("set-cookie");
+  _candidateFields.insert("vary");
+  _candidateFields.insert("x-frame-options");
+  _candidateFields.insert("x-xss-protection");
+  _candidateFields.insert("x-content-type-options");
+  _candidateFields.insert("x-forwarded-server");
+  _candidateFields.insert("x-forwarded-proto");
+  _candidateFields.insert("x-real-ip");
+  _candidateFields.insert("x-request-id");
+  _candidateFields.insert("x-correlation-id");
+  _candidateFields.insert("x-csrf-token");
+  _candidateFields.insert("x-device-user-agent");
+}
+
+CandidateFields& CandidateFields::getInstance() {
+  static CandidateFields instance;
+  return instance;
+}
+
+const std::set<std::string>& CandidateFields::getCandidateFields() {
+  return _candidateFields;
+}

--- a/srcs/clients/request/include/IRequest.hpp
+++ b/srcs/clients/request/include/IRequest.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+class IRequest {
+ public:
+  virtual ~IRequest() {}
+  void parseRequest(void);
+  void matchServerConf(short port);
+  void validatePath(void);
+};

--- a/srcs/clients/request/include/Request.hpp
+++ b/srcs/clients/request/include/Request.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <iostream>
+#include <list>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "CandidateFields.hpp"
+#include "Config.hpp"
+#include "IRequest.hpp"
+#include "RequestParser.hpp"
+#include "Status.hpp"
+
+class Request : public IRequest {
+ private:
+  Request();
+
+ public:
+  Request(std::string &request);
+  virtual ~Request();
+  Request(const Request &src);
+  Request &operator=(const Request &src);
+
+ private:
+  std::string _request;
+  std::string _method;
+  std::string _path;
+  std::string _protocol;
+  std::string _CGI;
+  Status _statusCode;
+  IRequestParser &_parser;
+  RequestDts _request_parser_dts;
+
+  std::list<std::string> _linesBuffer;
+  std::map<std::string, std::string> _headerFields;
+  std::map<std::string, std::string> _serverConf;
+  IServerConfig *_matchedServer;
+  ILocationConfig *_matchedLocation;
+
+  void initDts();
+
+ public:
+  void parseRequest(void);
+  void matchServerConf(short port);
+  void validatePath(void);
+};

--- a/srcs/clients/request/request_parser/include/IRequestParser.hpp
+++ b/srcs/clients/request/request_parser/include/IRequestParser.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <iostream>
+#include <list>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "CandidateFields.hpp"
+#include "Config.hpp"
+#include "IRequest.hpp"
+#include "Status.hpp"
+#include "Utils.hpp"
+
+typedef struct RequestDts {
+  std::string* request;
+  std::string* method;
+  std::string* path;
+  std::string* protocol;
+  std::string* CGI;
+  std::list<std::string>* linesBuffer;
+  std::map<std::string, std::string>* headerFields;
+  std::map<std::string, std::string>* serverConf;
+  IServerConfig* matchedServer;
+  ILocationConfig* matchedLocation;
+} RequestDts;
+
+class IRequestParser {
+ public:
+  virtual ~IRequestParser(){};
+
+  virtual void parseRequest(RequestDts& dts) = 0;
+  virtual void matchServerConf(short port, RequestDts& dts) = 0;
+  virtual void validatePath(RequestDts& dts) = 0;
+};

--- a/srcs/clients/request/request_parser/include/RequestParser.hpp
+++ b/srcs/clients/request/request_parser/include/RequestParser.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "IRequestParser.hpp"
+
+class RequestParser : public IRequestParser {
+ private:
+  RequestParser();
+  virtual ~RequestParser();
+  RequestParser(const RequestParser& src);
+  RequestParser& operator=(const RequestParser& src);
+
+  void splitLinesByCRLF(RequestDts& dts);
+
+  void parseRequestLine(RequestDts& dts);
+  void parseHeaderFields(RequestDts& dts);
+
+  std::string getFirstTokenOfPath(RequestDts& dts) const;
+  bool checkBodyExistance(std::list<std::string>::const_iterator it,
+                          RequestDts& dts) const;
+  bool checkPathForm(RequestDts& dts);
+  void setDefaultLocation(
+      std::list<ILocationConfig*>::const_iterator defaultLocation,
+      RequestDts& dts);
+
+ private:
+  const std::set<std::string>& _candidateFields;
+  Status _statusCode;
+
+ public:
+  void parseRequest(RequestDts& dts);
+  void matchServerConf(short port, RequestDts& dts);
+  void validatePath(RequestDts& dts);
+
+  static RequestParser& getInstance();
+};

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -1,0 +1,184 @@
+#include "RequestParser.hpp"
+
+RequestParser::RequestParser()
+    : _candidateFields(CandidateFields::getInstance().getCandidateFields()) {}
+
+RequestParser::~RequestParser() {}
+
+RequestParser::RequestParser(const RequestParser &src)
+    : _candidateFields(CandidateFields::getInstance().getCandidateFields()) {
+  *this = src;
+}
+
+RequestParser &RequestParser::operator=(const RequestParser &src) {
+  if (this != &src) {
+  }
+  return *this;
+}
+
+void RequestParser::splitLinesByCRLF(RequestDts &dts) {
+  size_t pos = 0;
+  size_t delimeter = dts.request->find("\r\n");
+  while (delimeter != std::string::npos) {
+    std::string chunk = dts.request->substr(pos, delimeter);
+    dts.linesBuffer->push_back(chunk);
+    pos = delimeter + 2;
+    delimeter = dts.request->find("\r\n", pos);
+  }
+}
+
+void RequestParser::parseRequestLine(RequestDts &dts) {
+  const std::string &firstLine(dts.linesBuffer->front());
+  int delim_cnt = 0;
+  size_t pos = firstLine.find(" ", 0);
+  while (pos != std::string::npos) {
+    delim_cnt++;
+    pos = firstLine.find(" ", ++pos);
+  }
+  if (delim_cnt != 2) throw(_statusCode = BAD_REQUEST);
+
+  std::istringstream iss(firstLine);
+  dts.linesBuffer->pop_front();
+  iss >> *dts.method >> *dts.path >> *dts.protocol;
+
+  std::cout << "method: " << dts.method << std::endl;
+  std::cout << "path: " << dts.path << std::endl;
+  std::cout << "protocol: " << dts.protocol << std::endl;
+  if (*dts.method == "" || *dts.path == "" || *dts.protocol == "")
+    throw(_statusCode = BAD_REQUEST);
+}
+
+void RequestParser::parseHeaderFields(RequestDts &dts) {
+  std::list<std::string>::const_iterator lineIt = dts.linesBuffer->begin();
+  std::list<std::string>::const_iterator lineEnd = dts.linesBuffer->end();
+
+  std::string key;
+  std::string value;
+
+  size_t pos = 0;
+  while (lineIt != lineEnd) {
+    pos = (*lineIt).find(": ");
+    key = toLowerString((*lineIt).substr(0, pos));
+    if (_candidateFields.find(key) != _candidateFields.end()) {
+      value =
+          toLowerString((*lineIt).substr(pos + 2, (*lineIt).size() - pos - 2));
+      // value 검증 필요
+      (*dts.headerFields)[key] = value;
+    }
+    ++lineIt;
+    dts.linesBuffer->pop_front();
+    if (checkBodyExistance(lineIt, dts)) {
+      dts.linesBuffer->pop_front();
+      return;
+    }
+  }
+}
+
+bool RequestParser::checkBodyExistance(
+    std::list<std::string>::const_iterator it, RequestDts &dts) const {
+  return (!dts.linesBuffer->empty() && *it == "");
+}
+
+bool RequestParser::checkPathForm(RequestDts &dts) {
+  std::string::const_iterator iter = dts.path->begin();
+  std::string::const_iterator end = dts.path->end();
+  if (*iter == '/') ++iter;
+  while (iter != end) {
+    if (*iter == '/' && *(iter + 1) == '/') return false;
+    ++iter;
+  }
+  return true;
+}
+
+void RequestParser::setDefaultLocation(
+    std::list<ILocationConfig *>::const_iterator defaultLocation,
+    RequestDts &dts) {
+  dts.matchedLocation = *defaultLocation;
+  dts.path->erase(0, 1);  // remove the first '/'
+  *dts.path = (*defaultLocation)->getRoot() + *dts.path;
+  dts.path->erase(0, 1);
+}
+
+void RequestParser::matchServerConf(short port, RequestDts &dts) {
+  dts.matchedServer = NULL;
+  Config &config = Config::getInstance();
+  std::list<IServerConfig *> serverInfo = config.getServerConfigs();
+  std::list<IServerConfig *>::iterator it = serverInfo.begin();
+  if (serverInfo.empty()) throw(42.42);
+  while (it != serverInfo.end()) {
+    if ((*it)->getListen() != port) {
+      ++it;
+      continue;
+    }
+    if ((*it)->getServerName() == (*dts.headerFields)["host"]) {
+      dts.matchedServer = *it;
+      return;
+    } else
+      dts.matchedServer = *it;
+    ++it;
+  }
+  if (dts.matchedServer == NULL) {
+#ifdef DEBUG_MSG
+    std::cout << "no matched server" << std::endl;
+#endif
+    throw(_statusCode = NOT_FOUND);
+  }
+}
+
+std::string RequestParser::getFirstTokenOfPath(RequestDts &dts) const {
+  size_t pos = dts.path->find("/", 1);
+  size_t end;
+  if (pos == std::string::npos)
+    end = dts.path->size();
+  else
+    end = pos;
+  return (dts.path->substr(0, end));
+}
+
+// /root//dir/test.txt
+// GET /dir/test.txt/ hTML/1.1
+void RequestParser::validatePath(RequestDts &dts) {
+  std::string firstToken = getFirstTokenOfPath(dts);
+#ifdef DEBUG_MSG
+  std::cout << "firstToken: " << firstToken << std::endl;
+#endif
+  std::list<ILocationConfig *>::const_iterator it =
+      dts.matchedServer->getLocationConfigs().begin();
+  std::list<ILocationConfig *>::const_iterator endIt =
+      dts.matchedServer->getLocationConfigs().end();
+  std::list<ILocationConfig *>::const_iterator defaultLocation;
+  while (it != endIt) {
+    const std::string &currRoute = (*it)->getRoute();
+#ifdef DEBUG_MSG
+    std::cout << "currRoute: " << currRoute << std::endl;
+#endif
+    if (currRoute == firstToken) {
+      dts.matchedLocation = *it;
+      dts.path->erase(0, firstToken.size());
+      if (dts.path->size() != 0 && (*dts.path)[0] == '/')
+        dts.path->erase(0, 1);  // remove this because there is already a
+                                // slash at the end of root path
+      *dts.path = (*it)->getRoot() + *dts.path;
+      dts.path->erase(0, 1);  // remove the first '/'
+#ifdef DEBUG_MSG
+      std::cout << "actual path: " << dts.path << '\n';
+#endif
+      if (this->checkPathForm(dts) == false) throw(_statusCode = NOT_FOUND);
+      return;
+    }
+    if (currRoute == "/") defaultLocation = it;
+    ++it;
+  }
+  this->setDefaultLocation(defaultLocation, dts);
+}
+
+void RequestParser::parseRequest(RequestDts &requestDts) {
+  this->splitLinesByCRLF(requestDts);
+  this->parseRequestLine(requestDts);
+  this->parseHeaderFields(requestDts);
+}
+
+RequestParser &RequestParser::getInstance() {
+  static RequestParser instance;
+  return instance;
+}

--- a/srcs/clients/request/src/Request.cpp
+++ b/srcs/clients/request/src/Request.cpp
@@ -1,0 +1,55 @@
+#include "Request.hpp"
+
+Request::Request() : _parser(RequestParser::getInstance()) { initDts(); }
+
+Request::Request(std::string &request)
+    : _parser(RequestParser::getInstance()), _request(request) {
+  initDts();
+}
+
+Request::~Request() {}
+
+Request::Request(const Request &src)
+    : _parser(RequestParser::getInstance()), _request(src._request) {
+  *this = src;
+}
+
+Request &Request::operator=(const Request &src) {
+  if (this != &src) {
+    this->_path = src._path;
+    this->_protocol = src._protocol;
+    this->_statusCode = src._statusCode;
+    this->_linesBuffer = src._linesBuffer;
+    this->_headerFields = src._headerFields;
+    this->_serverConf = src._serverConf;
+    this->_matchedServer = src._matchedServer;
+    this->_matchedLocation = src._matchedLocation;
+    this->_CGI = src._CGI;
+    this->_method = src._method;
+    this->_request = src._request;
+    this->_statusCode = src._statusCode;
+  }
+  initDts();
+  return *this;
+}
+
+void Request::initDts() {
+  _request_parser_dts.request = &_request;
+  _request_parser_dts.method = &_method;
+  _request_parser_dts.path = &_path;
+  _request_parser_dts.protocol = &_protocol;
+  _request_parser_dts.CGI = &_CGI;
+  _request_parser_dts.linesBuffer = &_linesBuffer;
+  _request_parser_dts.headerFields = &_headerFields;
+  _request_parser_dts.serverConf = &_serverConf;
+  _request_parser_dts.matchedServer = _matchedServer;
+  _request_parser_dts.matchedLocation = _matchedLocation;
+}
+
+void Request::parseRequest(void) { _parser.parseRequest(_request_parser_dts); }
+
+void Request::matchServerConf(short port) {
+  _parser.matchServerConf(port, _request_parser_dts);
+}
+
+void Request::validatePath(void) { _parser.validatePath(_request_parser_dts); }

--- a/srcs/clients/response/include/IResponse.hpp
+++ b/srcs/clients/response/include/IResponse.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+class IResponse {
+ public:
+  virtual ~IResponse() {}
+  virtual bool getResponseFlag(void) const = 0;
+  virtual const std::string &getResponse(void) const = 0;
+  virtual void assembleResponseLine(void) = 0;
+};

--- a/srcs/clients/response/include/Response.hpp
+++ b/srcs/clients/response/include/Response.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <iostream>
+
+#include "Config.hpp"
+#include "IResponse.hpp"
+#include "Status.hpp"
+#include "Utils.hpp"
+
+class Response : public IResponse {
+ public:
+  Response();
+  virtual ~Response();
+  Response(const Response &src);
+  Response &operator=(const Response &src);
+
+ private:
+  std::string _response;
+  bool _responseFlag;
+  bool _assembleFlag;
+  Status _statusCode;
+  std::string _body;
+  void resetResponse();
+
+ public:
+  virtual void createErrorResponse(void);
+  bool getResponseFlag(void) const;
+  const std::string &getResponse(void) const;
+  void assembleResponseLine(void);
+};

--- a/srcs/clients/response/src/Response.cpp
+++ b/srcs/clients/response/src/Response.cpp
@@ -1,0 +1,45 @@
+#include "Response.hpp"
+
+Response::Response()
+    : _responseFlag(false), _assembleFlag(false), _statusCode(Status::OK) {}
+
+const std::string &Response::getResponse(void) const {
+  return (this->_response);
+}
+
+bool Response::getResponseFlag(void) const { return (this->_responseFlag); }
+
+void Response::createErrorResponse(void) {
+  resetResponse();
+
+  this->assembleResponseLine();
+  // redirection response (300). need to replace the url with actual url
+  if (statusInfo[this->_statusCode].body == NULL) {
+    this->_response += "Location: ";
+    this->_response += "http://example.com/redirect_url\r\n";
+    this->_responseFlag = true;
+    return;
+  }
+  // response for status code 400 ~ 500
+  this->_response += "Content-Type: text/plain\r\n";
+  this->_response += "Content-Length: ";
+  this->_response += itos(statusInfo[this->_statusCode].contentLength);
+  this->_response += "\r\n\r\n";
+  this->_response += statusInfo[this->_statusCode].body;
+  this->_response += "\r\n";
+  this->_responseFlag = true;
+}
+
+void Response::assembleResponseLine(void) {
+  this->_response = "HTTP/1.1 ";
+  this->_response += statusInfo[this->_statusCode].code;
+  this->_response += " ";
+  this->_response += statusInfo[this->_statusCode].message;
+  this->_response += "\r\n";
+}
+
+void Response::resetResponse(void) {
+  if (this->_responseFlag == false) return;
+  this->_response.clear();
+  this->_responseFlag = false;
+}


### PR DESCRIPTION
## 작업내용
- [x] CandidateFields 분리
- [x] ResponseParser 분리
- [x] Request 분리
- [x] Response 분리

## 관련사항
- Request 와 Response에 필요한 유틸 메서드는 Amethod에서 동일 내용 분리하면서 필요한 내용을 구현하는 방식으로 진행하겠습니다.