### PR TITLE
refactor(EventHandler): change event handling structure

### DIFF
--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -54,21 +54,18 @@ void Client::receiveRequest(void) {
 }
 
 void Client::sendResponse() {
-  if (this->_flag != REQUEST_DONE) return;
   signal(SIGPIPE, SIG_DFL);
-  if (this->_method != NULL && this->_method->getResponseFlag() == true) {
-    const std::string &response = this->_method->getResponse();
-    ssize_t n = send(this->_sd, response.c_str(), response.size(), 0);
-    if (n <= 0) {
-      if (n == -1) throw Client::SendFailException();
-      signal(SIGPIPE, SIG_DFL);
-      throw Client::DisconnectedDuringSendException();
-    }
-    this->_request.clear();
-    this->_flag = END;
+  const std::string &response = this->_method->getResponse();
+  ssize_t n = send(this->_sd, response.c_str(), response.size(), 0);
+  if (n <= 0) {
+    if (n == -1) throw Client::SendFailException();
     signal(SIGPIPE, SIG_DFL);
-    return;
+    throw Client::DisconnectedDuringSendException();
   }
+  this->_request.clear();
+  this->_flag = END;
+  signal(SIGPIPE, SIG_DFL);
+  return;
 }
 
 void Client::newHTTPMethod(void) {

--- a/srcs/server/include/Kqueue.hpp
+++ b/srcs/server/include/Kqueue.hpp
@@ -25,6 +25,8 @@ class Kqueue {
   void addEvent(uintptr_t ident, int16_t filter, uint16_t flags,
                 uint32_t fflags, intptr_t data, void* udata);
   void addEvent(uintptr_t ident);
+  void enableEvent(uintptr_t ident, int16_t filter, void* udata);
+  void disableEvent(uintptr_t ident, int16_t filter, void* udata);
   static void deleteEvent(uintptr_t ident, int16_t filter);
   int newEvents(void);
 

--- a/srcs/server/src/Kqueue.cpp
+++ b/srcs/server/src/Kqueue.cpp
@@ -31,13 +31,31 @@ void Kqueue::addEvent(uintptr_t ident) {
   this->_eventsToAdd.push_back(temp_event);
 }
 
+void Kqueue::disableEvent(uintptr_t ident, int16_t filter, void* udata) {
+  struct kevent temp_event;
+
+  EV_SET(&temp_event, ident, filter, EV_DISABLE, 0, 0, udata);
+  int ret = kevent(Kqueue::_kq, &temp_event, 1, NULL, 0, NULL);
+  if (ret == -1)
+    throwWithPerror("kevent() error on disableEvent()\n" + std::string(strerror(errno)));
+}
+
+void Kqueue::enableEvent(uintptr_t ident, int16_t filter, void* udata) {
+  struct kevent temp_event;
+
+  EV_SET(&temp_event, ident, filter, EV_ENABLE, 0, 0, udata);
+  int ret = kevent(Kqueue::_kq, &temp_event, 1, NULL, 0, NULL);
+  if (ret == -1)
+    throwWithPerror("kevent() error on enableEvent()\n" + std::string(strerror(errno)));
+}
+
 void Kqueue::deleteEvent(uintptr_t ident, int16_t filter) {
   struct kevent temp_event;
 
   EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, NULL);
   int ret = kevent(Kqueue::_kq, &temp_event, 1, NULL, 0, NULL);
   if (ret == -1)
-    throwWithPerror("kevent() error he eung\n" + std::string(strerror(errno)));
+    throwWithPerror("kevent() error on deleteEvent\n" + std::string(strerror(errno)));
 }
 
 int Kqueue::newEvents() {


### PR DESCRIPTION
- 클라이언트에 대한 쓰기 이벤트가 이제 활성화/비활성화를 통해 관리됩니다.
  - 응답 생성이 완료되면 클라이언트 소켓의 쓰기 이벤트를 활성화시켜서 다음 루프에서 eventList[]에 올라오게 됩니다.
  - Kqueue 클래스에 enableEvent(), disableEvent() 메서드를 추가하였습니다.
  - Client::sendResponse() 에서 더 이상 플래그를 체크하지 않습니다.
  - 응답을 송신한 후 다시 쓰기 이벤트를 비활성화 시킵니다.