### PR TITLE
feat(EventHandler): register fd to kqueue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ sources1 +=	Client.cpp
 sources1 +=	ServerManager.cpp \
 						Server.cpp \
 						Kqueue.cpp \
-						EventHandler.cpp
+						EventHandler.cpp \
+						FdInfo.cpp
 
 # ---- HTTP ---- #
 

--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -16,17 +16,12 @@
 #define RECEIVE_LEN 1000
 
 enum ClientFlag {
-  START,
   RECEIVING,
   RECEIVE_DONE,
-  REQUEST_HEAD,
-  REQUEST_ENTITY,
-  REQUEST_DONE,
-  FILE_READ,
-  FILE_CGI,
-  FILE_WRITE,
-  FILE_DONE,
-  RESPONSE_DONE,
+  REQUEST_PARSED,
+  FILE_IO,
+  PIPE_IO,
+  RESPONSE_CREATED,
   END
 };
 
@@ -40,6 +35,7 @@ class Client {
   Request _request;
   Response _response;
   IMethod *_method;
+  FdInfo _fdInfo;
 
   static char _buf[RECEIVE_LEN + 1];
 
@@ -55,6 +51,7 @@ class Client {
  public:
   uintptr_t getSD() const;
   IMethod *getMethod() const;
+  const FdInfo &getFdInfo() const;
   void receiveRequest();
   void newHTTPMethod();
   void sendResponse();

--- a/srcs/clients/fdinfo/include/FdInfo.hpp
+++ b/srcs/clients/fdinfo/include/FdInfo.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+enum FdType { NONE, FILE_READ, FILE_WRITE, PIPE };
+
+class FdInfo {
+ private:
+  FdType _fdType;
+  int _readFd;
+  int _writeFd;
+
+ public:
+  FdInfo();
+  FdInfo(const FdInfo& src);
+  FdInfo& operator=(const FdInfo& src);
+  ~FdInfo();
+
+  FdType getFdType(void) const;
+  int getReadFd(void) const;
+  int getWriteFd(void) const;
+
+  void setReadFd(int fd);
+  void setWriteFd(int fd);
+  void setPipeFd(int readEnd, int writeEnd);
+
+  bool isFileIO(void) const;
+  bool isPipeIO(void) const;
+};

--- a/srcs/clients/fdinfo/src/FdInfo.cpp
+++ b/srcs/clients/fdinfo/src/FdInfo.cpp
@@ -1,0 +1,39 @@
+#include "FdInfo.hpp"
+
+FdInfo::FdInfo() : _fdType(NONE), _readFd(-1), _writeFd(-1) {}
+FdInfo::FdInfo(const FdInfo& src)
+    : _fdType(src._fdType), _readFd(src._readFd), _writeFd(src._writeFd) {}
+
+FdInfo& FdInfo::operator=(const FdInfo& src) {
+  if (this != &src) {
+    this->_fdType = src._fdType;
+    this->_readFd = src._readFd;
+    this->_writeFd = src._writeFd;
+  }
+  return *this;
+}
+
+FdInfo::~FdInfo() {}
+
+FdType FdInfo::getFdType(void) const { return (this->_fdType); }
+int FdInfo::getReadFd(void) const { return (this->_readFd); }
+int FdInfo::getWriteFd(void) const { return (this->_writeFd); }
+
+void FdInfo::setReadFd(int fd) {
+  this->_fdType = FILE_READ;
+  this->_readFd = fd;
+}
+void FdInfo::setWriteFd(int fd) {
+  this->_fdType = FILE_WRITE;
+  this->_writeFd = fd;
+}
+void FdInfo::setPipeFd(int readEnd, int writeEnd) {
+  this->_fdType = PIPE;
+  this->_readFd = readEnd;
+  this->_writeFd = writeEnd;
+}
+
+bool FdInfo::isFileIO(void) const {
+  return (this->_fdType == FILE_READ || this->_fdType == FILE_WRITE);
+}
+bool FdInfo::isPipeIO(void) const { return (this->_fdType == PIPE); }

--- a/srcs/clients/method/include/DELETE.hpp
+++ b/srcs/clients/method/include/DELETE.hpp
@@ -13,7 +13,7 @@ class DELETE : public IMethod {
   DELETE();
   ~DELETE();
 
-  void doRequest(RequestDts& dts, IResponse& response);
+  void doRequest(RequestDts& dts, IResponse& response, FdInfo &fdInfo);
   void createSuccessResponse(IResponse& response);
 };
 

--- a/srcs/clients/method/include/DummyMethod.hpp
+++ b/srcs/clients/method/include/DummyMethod.hpp
@@ -8,7 +8,7 @@ class DummyMethod : public IMethod {
   DummyMethod(Status statusCode);
   ~DummyMethod();
 
-  void doRequest(RequestDts& dts, IResponse& response);
+  void doRequest(RequestDts& dts, IResponse& response, FdInfo &fdInfo);
   void createSuccessResponse(IResponse& response);
 };
 

--- a/srcs/clients/method/include/GET.hpp
+++ b/srcs/clients/method/include/GET.hpp
@@ -29,7 +29,7 @@ class GET : public IMethod {
   GET();
   ~GET();
 
-  void doRequest(RequestDts& dts, IResponse& response);
+  void doRequest(RequestDts& dts, IResponse& response, FdInfo &fdInfo);
   void fileHandler(const std::string& path);
   void createSuccessResponse(IResponse& response);
 };

--- a/srcs/clients/method/include/GET.hpp
+++ b/srcs/clients/method/include/GET.hpp
@@ -9,7 +9,7 @@ class GET : public IMethod {
   std::string _contentType;
 
   std::vector<std::string> getFileList(const std::string& path,
-                                       RequestDts& dts);
+                                       RequestDts& dts, std::vector<std::string> &files);
   std::string generateHTML(const std::vector<std::string>& files);
   void validateContentType(IResponse &response);
   void prepareFileList(const std::string& path, RequestDts& dts,
@@ -19,6 +19,11 @@ class GET : public IMethod {
 
   void prepareTextBody(const std::string& path, IResponse& response);
   void prepareBinaryBody(const std::string& path, IResponse& response);
+
+  std::string makePathIndex(RequestDts& dts);
+
+  bool checkFilePath(const std::string &path);
+  bool checkDirectoryPath(const std::string &pathIndex, RequestDts &dts);
 
  public:
   GET();

--- a/srcs/clients/method/include/IMethod.hpp
+++ b/srcs/clients/method/include/IMethod.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "Config.hpp"
+#include "FdInfo.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
 #include "Status.hpp"
@@ -12,7 +13,8 @@
 class IMethod {
  public:
   virtual ~IMethod(){};
-  virtual void doRequest(RequestDts& dts, IResponse &response) = 0;
+  virtual void doRequest(RequestDts& dts, IResponse& response,
+                         FdInfo& fdInfo) = 0;
   // virtual int fileHandler(const std::string& path);
   virtual void createSuccessResponse(IResponse& response) = 0;
 };

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -20,7 +20,7 @@ class POST : public IMethod {
   POST();
   ~POST();
 
-  void doRequest(RequestDts& dts, IResponse& response);
+  void doRequest(RequestDts& dts, IResponse& response, FdInfo &fdInfo);
   void createSuccessResponse(IResponse& response);
   void appendBody();
   void generateUrlEncoded(RequestDts& dts, IResponse& response);

--- a/srcs/clients/method/src/DELETE.cpp
+++ b/srcs/clients/method/src/DELETE.cpp
@@ -3,8 +3,9 @@
 DELETE::DELETE() {}
 DELETE::~DELETE() {}
 
-void DELETE::doRequest(RequestDts& dts, IResponse &response) {
+void DELETE::doRequest(RequestDts& dts, IResponse &response, FdInfo &fdInfo) {
   (void)response;
+  (void)fdInfo;
   if (std::remove(dts.path->c_str()) == false) {
     throw(*dts.statusCode = NOT_FOUND);
   }

--- a/srcs/clients/method/src/DummyMethod.cpp
+++ b/srcs/clients/method/src/DummyMethod.cpp
@@ -3,7 +3,7 @@
 DummyMethod::DummyMethod(Status statusCode) { (void)statusCode; }
 DummyMethod::~DummyMethod() {}
 
-void DummyMethod::doRequest(RequestDts& dts,IResponse &response ) { (void)dts;
-  (void)response;
+void DummyMethod::doRequest(RequestDts& dts,IResponse &response, FdInfo &fdInfo) { (void)dts;
+  (void)response; (void)fdInfo;
 }
 void DummyMethod::createSuccessResponse(IResponse& response) { (void)response; }

--- a/srcs/clients/method/src/GET.cpp
+++ b/srcs/clients/method/src/GET.cpp
@@ -15,9 +15,10 @@
 GET::GET() : IMethod() {}
 GET::~GET() {}
 
-void GET::doRequest(RequestDts& dts, IResponse& response) {
+void GET::doRequest(RequestDts& dts, IResponse& response, FdInfo& fdInfo) {
   response.setHeaderField("Content-Type", "text/plain");
   std::string pathIndex = makePathIndex(dts);
+  (void)fdInfo;
 
 #ifdef DEBUG_MSG
   std::cout << " -- this : " << *dts.path << std::endl;

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -10,8 +10,9 @@ POST::POST(void) {}
 
 POST::~POST(void) {}
 
-void POST::doRequest(RequestDts& dts, IResponse &response) {
+void POST::doRequest(RequestDts& dts, IResponse &response, FdInfo& fdInfo) {
   (void)response;
+  (void)fdInfo;
   this->generateFile(dts);
   *dts.statusCode = CREATED;
 }

--- a/srcs/server/include/EventHandler.hpp
+++ b/srcs/server/include/EventHandler.hpp
@@ -20,7 +20,8 @@ class EventHandler : public Kqueue {
   void checkErrorOnSocket(void);
   void acceptClient(void);
   void disconnectClient(const Client* client);
-  void registClient(const uintptr_t clientSocket);
+  void registerClient(const uintptr_t clientSocket);
+  void registerIOEvent(Client& client);
   void processRequest(Client& client);
   void processResponse(Client& client);
 

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -147,11 +147,13 @@ void EventHandler::registerIOEvent(Client &client) {
   if (fdInfo.getFdType() == FILE_READ) {
     addEvent(fdInfo.getReadFd(), EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
              static_cast<void *>(&client));
+    client.setFlag(FILE_IO);
     return;
   }
   if (fdInfo.getFdType() == FILE_WRITE) {
     addEvent(fdInfo.getWriteFd(), EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
              static_cast<void *>(&client));
+    client.setFlag(FILE_IO);
     return;
   }
   if (fdInfo.getFdType() == PIPE) {
@@ -159,6 +161,7 @@ void EventHandler::registerIOEvent(Client &client) {
              static_cast<void *>(&client));
     addEvent(fdInfo.getWriteFd(), EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0,
              static_cast<void *>(&client));
+    client.setFlag(PIPE_IO);
     return;
   }
 }


### PR DESCRIPTION
- 파일 혹은 파이프의 fd 정보를 저장하는 FdInfo객체를 Client 객체에 추가하였습니다.
- HTTP 메소드 내부에서 파일 혹은 파이프를 생성한 경우, fd를 FdInfo 객체에 저장한 다음 doRequest() 에서 리턴하면 EventHandler::registerIOEvent() 에서 FdInfo객체를 참조하여 이벤트를 등록한 후, Client flag를 FILE_IO 혹은 PIPE_IO로 변경합니다.
- 이후에 해당 IO 이벤트 발생 시, Client flag를 통해 분기하여 읽기/쓰기 후 적절한 응답을 생성하여 소켓에 대한 쓰기 이벤트를 활성화시키는 부분은 추가 구현이 필요합니다.
- 이외에 GET 메서드를 리팩토링 하였습니다.