### PR TITLE
feat(POST): apply new concept of dts structure

### DIFF
--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -23,7 +23,7 @@ class POST : public IMethod {
   void generateUrlEncoded(RequestDts& dts, IResponse& response);
   void generateMultipart(RequestDts& dts, IResponse& response);
   void prepareTextBody(RequestDts& dts);
-  void prepareBinaryBody(const std::string& filename);
+  void prepareBinaryBody(RequestDts& dts);
 
   std::string decodeURL(std::string encoded_string);
 

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -20,15 +20,12 @@ class POST : public IMethod {
 
   void doRequest(RequestDts& dts, IResponse& response);
   void createSuccessResponse(IResponse& response);
-  void appendBody();
   void generateUrlEncoded(RequestDts& dts, IResponse& response);
   void generateMultipart(RequestDts& dts, IResponse& response);
-  void prepareTextBody(const std::string& body);
+  void prepareTextBody(RequestDts& dts);
   void prepareBinaryBody(const std::string& filename);
 
-  std::string createHTML(std::string const& head);
-
-  std::string decodeURL(std::string const& encoded_string);
+  std::string decodeURL(std::string encoded_string);
 
   // std::string validateContentType();
 };

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -5,14 +5,12 @@
 
 class POST : public IMethod {
  private:
-  void generateFile(RequestDts& dts);
-  std::string _body;
+  // void generateFile(RequestDts& dts);
   std::string _contentType;
+  std::string _body;
   std::string _path;
   std::string _title;
   std::string _content;
-  std::string _disposName;
-  std::string _disposFilename;
   std::string _type;
   void generateResource(RequestDts& dts, IResponse& response);
 

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -27,7 +27,7 @@ class POST : public IMethod {
   void generateMultipart(RequestDts& dts, IResponse& response);
   void prepareTextBody(const std::string& body);
   void prepareBinaryBody(const std::string& filename);
-  void createDisposSuccessResponse(IResponse& response);
+
   std::string createHTML(std::string const& head);
 
   std::string decodeURL(std::string const& encoded_string);

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -12,7 +12,7 @@ class POST : public IMethod {
   std::string _title;
   std::string _content;
   std::string _type;
-  void generateResource(RequestDts& dts, IResponse& response);
+  void generateResource(RequestDts& dts);
 
  public:
   POST();
@@ -20,8 +20,8 @@ class POST : public IMethod {
 
   void doRequest(RequestDts& dts, IResponse& response);
   void createSuccessResponse(IResponse& response);
-  void generateUrlEncoded(RequestDts& dts, IResponse& response);
-  void generateMultipart(RequestDts& dts, IResponse& response);
+  void generateUrlEncoded(RequestDts& dts);
+  void generateMultipart(RequestDts& dts);
   void prepareTextBody(RequestDts& dts);
   void prepareBinaryBody(RequestDts& dts);
 

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -10,7 +10,7 @@ POST::POST(void) {}
 
 POST::~POST(void) {}
 
-void POST::doRequest(RequestDts& dts, IResponse &response) {
+void POST::doRequest(RequestDts& dts, IResponse& response) {
   (void)response;
   this->generateFile(dts);
   *dts.statusCode = CREATED;
@@ -115,24 +115,10 @@ void POST::prepareBinaryBody(const std::string& filename) {
 }
 
 void POST::createSuccessResponse(IResponse& response) {
-  // response.assembleResponseLine();
-  // response.addResponse(getCurrentTime());
-  // response.addResponse("Content-Type: text/html; charset=UTF-8\r\n");
-  // response.addResponse("Content-Length: ");
-  // response.addResponse(itos(this->_body.size()));
-  this->createHTML(this->_title);
-  // std::cout << this->_response << "\n";
-  response.setResponseParsed();
-}
-
-void POST::createDisposSuccessResponse(IResponse& response) {
-  // response.assembleResponseLine();
-  // response.addResponse(getCurrentTime());
-  // response.addResponse("Content-Type: text/html; charset=UTF-8\r\n");
-  // response.addResponse("Content-Length: ");
-  // response.addResponse(itos(this->_body.size()));
-  this->createHTML(this->_disposFilename);
-  // std::cout << this->_response << "\n";
+  const std::string& value = response.getFieldValue("Content-Type");
+  response.setHeaderField("Content-Type", value + "; charset=UTF-8");
+  response.setHeaderField("Date", getCurrentTime());
+  response.assembleResponse();
   response.setResponseParsed();
 }
 

--- a/srcs/clients/response/include/IResponse.hpp
+++ b/srcs/clients/response/include/IResponse.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "Status.hpp"
 #include <string>
 
 class IResponse {
  public:
   virtual ~IResponse() {}
   virtual bool getResponseFlag(void) const = 0;
+  virtual Status getStatus(void) = 0;
   virtual const std::string &getResponse(void) const = 0;
   virtual const std::string &getBody(void) const = 0;
   virtual std::string &getFieldValue(const std::string &key) = 0;
@@ -15,6 +17,7 @@ class IResponse {
   virtual void setHeaderField(const std::string &key,
                               const std::string &value) = 0;
   virtual void setBody(const std::string &str) = 0;
+  virtual void setStatusCode(Status code) = 0;
   virtual void setResponseParsed() = 0;
   virtual bool isParsed() = 0;
 };

--- a/srcs/clients/response/include/Response.hpp
+++ b/srcs/clients/response/include/Response.hpp
@@ -31,10 +31,10 @@ class Response : public IResponse {
  public:
   virtual void createErrorResponse(void);
   bool getResponseFlag(void) const;
+  Status getStatus(void);
   const std::string &getResponse(void) const;
   const std::string &getBody(void) const;
   std::string &getFieldValue(const std::string &key);
-
   void assembleResponse(void);
 
   void eraseHeaderField(const std::string &key);
@@ -42,6 +42,7 @@ class Response : public IResponse {
 
   void setHeaderField(const std::string &key, const std::string &value);
   void setBody(const std::string &str);
+  void setStatusCode(Status code);
   void setResponseParsed();
   bool isParsed();
 };

--- a/srcs/clients/response/src/Response.cpp
+++ b/srcs/clients/response/src/Response.cpp
@@ -5,7 +5,7 @@
 Response::Response()
     : _responseFlag(false),
       _assembleFlag(false),
-      _statusCode(this->_statusCode = OK) {}
+      _statusCode(CREATED) {}
 
 Response::~Response() {}
 
@@ -29,6 +29,8 @@ const std::string &Response::getResponse(void) const {
 const std::string &Response::getBody(void) const { return (this->_body); }
 
 bool Response::getResponseFlag(void) const { return (this->_responseFlag); }
+
+Status Response::getStatus(void) { return (this->_statusCode); }
 
 std::string &Response::getFieldValue(const std::string &key) {
   return (this->_headerFields[key]);
@@ -93,6 +95,8 @@ void Response::putBody(void) {
   if (this->_body.empty() == true) return;
   this->_response += "\r\n" + this->_body;
 }
+
+void Response::setStatusCode(Status code) { this->_statusCode = code; }
 
 void Response::setHeaderField(const std::string &key,
                               const std::string &value) {


### PR DESCRIPTION
- POST 를 dts폼에 맞게 바꾸는 작업을 진행했습니다.
- 추가적으로, form-urlencoded의 POST요청이 들어왔을 때, title/content 를 키값으로 들고있는 형태를 받아 content의 내용을 들고있게하는 title.txt 파일 생성이 가능하게 했습니다. 
- multipart-form 의 POST요청에 대해 body가 string 형태로 들고있어서 binary 파일을 읽지못하고 있어서 추후 수정예정입니다.
- 이외에도, Response에서 statusCode에 대한 getter/setter를 추가했습니다.