### PR TITLE
87 feateventhandler keep alive

### DIFF
--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -70,6 +70,7 @@ class Client {
   void createErrorResponse(Status statusCode);
   void createSuccessResponse();
   void makeAndExecuteCgi();
+  void clear();
   ClientFlag getFlag() const;
   class RecvFailException : public std::exception {
    public:

--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -29,7 +29,8 @@ enum ClientFlag {
   FILE_WRITE,
   FILE_DONE,
   RESPONSE_DONE,
-  END
+  END_KEEP_ALIVE,
+  END_CLOSE
 };
 
 class Utils;

--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -33,8 +33,9 @@ Client::~Client(void) {
   std ::cout << " Client destructor called " << this->getSD() << " !"
              << std::endl;
 #endif
-  // if (_method) delete _method;
-  // if (_cgi) delete _cgi;
+  close(_sd);
+  if (_method != NULL) delete _method;
+  if (_cgi != NULL) delete _cgi;
 }
 
 bool Client::checkIfReceiveFinished(ssize_t n) {

--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -161,3 +161,20 @@ void Client::makeAndExecuteCgi() {
   _cgi = new CGI(&_request, &_response, _sd, static_cast<void *>(this));
   _cgi->executeCGI();
 }
+
+void Client::clear() {
+  _flag = RECEIVING;
+  _recvBuff.clear();
+
+  _request.clear();
+  _response.clear();
+
+  if (_cgi != NULL) {
+    delete _cgi;
+    _cgi = NULL;
+  }
+  if (_method != NULL) {
+    delete _method;
+    _method = NULL;
+  }
+}

--- a/srcs/clients/request/include/IRequest.hpp
+++ b/srcs/clients/request/include/IRequest.hpp
@@ -26,4 +26,5 @@ class IRequest {
   virtual IServerConfig *getMatchedServer(void) const = 0;
 
   virtual const std::string getHeaderField(std::string key) const = 0;
+  virtual void clear(void) = 0;
 };

--- a/srcs/clients/request/include/Request.hpp
+++ b/srcs/clients/request/include/Request.hpp
@@ -13,8 +13,13 @@ class Request : public IRequest {
   Request &operator=(const Request &src);
 
  private:
+  IRequestParser &_parser;
+  RequestDts _request_parser_dts;
+
+ private:
   bool _isParsed;
   bool _is_cgi;
+
   size_t _contentLength;
 
   std::string _request;
@@ -25,17 +30,18 @@ class Request : public IRequest {
   std::string _cgi_path;
   std::string _body;
   std::string _query_string;
+
   Status _statusCode;
-  IRequestParser &_parser;
-  RequestDts _request_parser_dts;
 
   std::list<std::string> _linesBuffer;
   std::map<std::string, std::string> _headerFields;
   std::map<std::string, std::string> _queryStringElements;
   std::map<std::string, std::string> _serverConf;
+
   IServerConfig *_matchedServer;
   ILocationConfig *_matchedLocation;
 
+ private:
   void initDts();
   void initMember();
 
@@ -61,6 +67,8 @@ class Request : public IRequest {
 
   const bool &isParsed(void) const;
   const bool &isCgi(void) const;
+
+  void clear(void);
 };
 
 std::ostream &operator<<(std::ostream &os, const Request &request);

--- a/srcs/clients/request/src/Request.cpp
+++ b/srcs/clients/request/src/Request.cpp
@@ -6,7 +6,7 @@ Request::Request() : _parser(RequestParser::getInstance()) {
 }
 
 Request::Request(const std::string &request)
-    : _request(request), _parser(RequestParser::getInstance()) {
+    : _parser(RequestParser::getInstance()), _request(request) {
   initMember();
   initDts();
 }
@@ -14,7 +14,7 @@ Request::Request(const std::string &request)
 Request::~Request() {}
 
 Request::Request(const Request &src)
-    : _request(src._request), _parser(RequestParser::getInstance()) {
+    : _parser(RequestParser::getInstance()), _request(src._request) {
   *this = src;
 }
 
@@ -46,14 +46,33 @@ Request &Request::operator=(const Request &src) {
 
 void Request::initMember() {
   _isParsed = false;
-  _contentLength = 0;
   _is_cgi = false;
-  _matchedServer = 0;
-  _matchedLocation = 0;
+
+  _contentLength = 0;
+
+  _request.clear();
+  _method.clear();
+  _path.clear();
+  _anchor.clear();
+  _protocol.clear();
+  _cgi_path.clear();
+  _body.clear();
+  _query_string.clear();
+
+  _headerFields.clear();
+  _queryStringElements.clear();
+  _serverConf.clear();
+
+  _matchedServer = NULL;
+  _matchedLocation = NULL;
 }
 
 void Request::initDts() {
-  _request_parser_dts.statusCode = &_statusCode;
+  _request_parser_dts.isParsed = &_isParsed;
+  _request_parser_dts.is_cgi = &_is_cgi;
+
+  _request_parser_dts.contentLength = &_contentLength;
+
   _request_parser_dts.request = &_request;
   _request_parser_dts.method = &_method;
   _request_parser_dts.path = &_path;
@@ -61,26 +80,29 @@ void Request::initDts() {
   _request_parser_dts.protocol = &_protocol;
   _request_parser_dts.cgi_path = &_cgi_path;
   _request_parser_dts.body = &_body;
+  _request_parser_dts.query_string = &_query_string;
+
+  _request_parser_dts.statusCode = &_statusCode;
+
   _request_parser_dts.linesBuffer = &_linesBuffer;
   _request_parser_dts.headerFields = &_headerFields;
-  _request_parser_dts.query_string = &_query_string;
   _request_parser_dts.queryStringElements = &_queryStringElements;
   _request_parser_dts.serverConf = &_serverConf;
+
   _request_parser_dts.matchedServer = &_matchedServer;
   _request_parser_dts.matchedLocation = &_matchedLocation;
-  _request_parser_dts.isParsed = &_isParsed;
-  _request_parser_dts.is_cgi = &_is_cgi;
-  _request_parser_dts.contentLength = &_contentLength;
 }
 
 void Request::parseRequest(short port) {
+  initMember();
+  initDts();
   _parser.parseRequest(_request_parser_dts, port);
 }
 
 void Request::parseRequest(const std::string &request, short port) {
-  _request = request;
-  _request_parser_dts.request = &_request;
-  std::cout << "request: " << _request << std::endl;
+  initMember();
+  _request += request;
+  initDts();
   _parser.parseRequest(_request_parser_dts, port);
 }
 
@@ -131,6 +153,10 @@ std::ostream &operator<<(std::ostream &os, const Request &request) {
   os << request.getMethod() << request.getRequest() << request.getPath()
      << request.getProtocol() << request.getCgiPath() << request.getBody()
      << std::endl;
-
   return os;
+}
+
+void Request::clear() {
+  initMember();
+  initDts();
 }

--- a/srcs/clients/response/include/IResponse.hpp
+++ b/srcs/clients/response/include/IResponse.hpp
@@ -23,4 +23,5 @@ class IResponse {
   virtual bool isParsed() = 0;
 
   virtual void setResponse(std::string response) = 0;
+  virtual void clear(void) = 0;
 };

--- a/srcs/clients/response/include/Response.hpp
+++ b/srcs/clients/response/include/Response.hpp
@@ -49,4 +49,5 @@ class Response : public IResponse {
   bool isParsed();
 
   void setResponse(std::string response);
+  void clear(void);
 };

--- a/srcs/clients/response/src/Response.cpp
+++ b/srcs/clients/response/src/Response.cpp
@@ -142,3 +142,12 @@ void Response::configureErrorPages(RequestDts &dts) {
     file.close();
   }
 }
+
+void Response::clear() {
+  this->_response.clear();
+  this->_responseFlag = false;
+  this->_assembleFlag = false;
+  this->_statusCode = E_200_OK;
+  this->_body.clear();
+  this->_headerFields.clear();
+}

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -142,8 +142,7 @@ void EventHandler::disconnectClient(const Client *client) {
   Kqueue::deleteEvent((uintptr_t)client->getSD(), EVFILT_WRITE);
   Kqueue::deleteEvent((uintptr_t)client->getSD(), EVFILT_READ);
   Kqueue::deleteFdSet((uintptr_t)client->getSD(), FD_CLIENT);
-  close(client->getSD());
-  if (client->getMethod() != NULL) delete client->getMethod();
+
   std::cout << "Client " << client->getSD() << " disconnected!" << std::endl;
   delete client;
 }

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -129,8 +129,7 @@ void EventHandler::processResponse(Client &currClient) {
   if (currClient.getFlag() == END_KEEP_ALIVE) {
     disableEvent(currClient.getSD(), EVFILT_WRITE,
                  static_cast<void *>(&currClient));
-    // clearClient();
-    currClient.setFlag(RECEIVING);
+    currClient.clear();
     return;
   }
   if (currClient.getFlag() == END_CLOSE) {


### PR DESCRIPTION
## 작업내용
- [x] disconnecClient 로직에 있던 클라이언트 인스턴스 멤버 정리는 클라이언트 소멸자로 책임을 위임함니다.
- [x] 클라이언트 End 상태를 request connection 헤더 값에 따라 2가지 형태로 구분합니다.
- [x] Response, Request, Client 객체의 인스턴스 멤버를 초기화하는 clear 함수를 구현합니다.
- [x] connection 헤더에 따라 소켓 연결을 해제하거나, 클라이언트 멤버만 초기화 및 wrtie 이벤트를 disable 하는 작업을 진행
- [x] Client::sendResponse 함수의 분기는 다음과 같이 진행됩니다.
| send 실패여부
| client 단에서 소켓 연결이 끊어짐
| send가 끝까지 완료되지 않음
| send 완료시 connection에 헤더 따라 객체 status를 END_KEEP_ALIVE, END_CLOSE 로 결정