### PR TITLE
feat(POST): implement multipart-form/data

### DIFF
--- a/srcs/clients/candidate_fields/srcs/CandidateFields.cpp
+++ b/srcs/clients/candidate_fields/srcs/CandidateFields.cpp
@@ -16,6 +16,7 @@ CandidateFields::~CandidateFields() {}
 void CandidateFields::initCandidateFields() {
   _candidateFields.insert("host");
   _candidateFields.insert("accept");
+  _candidateFields.insert("transfer-encoding");
   _candidateFields.insert("accept-language");
   _candidateFields.insert("accept-encoding");
   _candidateFields.insert("accept-charset");

--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -15,7 +15,7 @@
 #include "Request.hpp"
 #include "Response.hpp"
 
-#define RECEIVE_LEN 1000
+#define RECEIVE_LEN 1460 * 2
 
 enum ClientFlag {
   START,

--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -45,7 +45,7 @@ class Client {
   IMethod *_method;
   ICGI *_cgi;
 
-  static char _buf[RECEIVE_LEN + 1];
+  static char _buf[RECEIVE_LEN];
 
   bool checkIfReceiveFinished(ssize_t n);
   // std::map<uintptr_t, char *> _clientBuf;

--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -15,7 +15,7 @@
 #include "Request.hpp"
 #include "Response.hpp"
 
-#define RECEIVE_LEN 1460 * 2
+#define RECEIVE_LEN 1460
 
 enum ClientFlag {
   START,

--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -6,7 +6,7 @@
 #include "POST.hpp"
 #include "Utils.hpp"
 
-char Client::_buf[RECEIVE_LEN + 1] = {0};
+char Client::_buf[RECEIVE_LEN] = {0};
 
 Client::Client() : _flag(START), _sd(0), _method(NULL) {
   this->_method = NULL;
@@ -52,10 +52,9 @@ void Client::receiveRequest(void) {
       if (n == -1) throw Client::RecvFailException();
       throw Client::DisconnectedDuringRecvException();
     }
-    Client::_buf[n] = '\0';
-    this->_recvBuff += Client::_buf;
-
-    std::memset(Client::_buf, 0, RECEIVE_LEN + 1);
+    this->_recvBuff.insert(this->_recvBuff.end(), Client::_buf,
+                           Client::_buf + n);
+    std::memset(Client::_buf, 0, RECEIVE_LEN);
     if (checkIfReceiveFinished(n) == true) {
 #ifdef DEBUG_MSG
       std::cout << "received data from " << this->_sd << ": " << this->_request

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -5,13 +5,14 @@
 
 class POST : public IMethod {
  private:
-  // void generateFile(RequestDts& dts);
   std::string _contentType;
+  std::string _boundary;
   std::string _body;
   std::string _path;
   std::string _title;
   std::string _content;
   std::string _type;
+
   void generateResource(RequestDts& dts);
 
  public:

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -1,17 +1,18 @@
 #ifndef POST_HPP
 #define POST_HPP
 
+#include <sys/stat.h>
+
 #include "IMethod.hpp"
 
 class POST : public IMethod {
  private:
   std::string _contentType;
   std::string _boundary;
-  std::string _body;
-  std::string _path;
   std::string _title;
   std::string _content;
-  std::string _type;
+
+  struct stat fileinfo;
 
   void generateResource(RequestDts& dts);
 
@@ -23,8 +24,8 @@ class POST : public IMethod {
   void createSuccessResponse(IResponse& response);
   void generateUrlEncoded(RequestDts& dts);
   void generateMultipart(RequestDts& dts);
-  void prepareTextBody(RequestDts& dts);
-  void prepareBinaryBody(RequestDts& dts);
+  void writeTextBody(RequestDts& dts);
+  void writeBinaryBody(RequestDts& dts);
 
   std::string decodeURL(std::string encoded_string);
 

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -92,19 +92,29 @@ void POST::generateMultipart(RequestDts& dts) {
 }
 
 void POST::writeTextBody(RequestDts& dts) {
+  std::string filename;
   if (stat(dts.path->c_str(), &fileinfo) != 0)
     throw((*dts.statusCode) = E_403_FORBIDDEN);
-  std::string pathInfo = *dts.path + this->_title + ".txt";
-  std::cout << "pathInfo: " << pathInfo << "\n";
-  std::ofstream file(pathInfo, std::ios::out);
+  if ((*dts.path)[dts.path->length() - 1] != '/')
+    filename = *dts.path + "/" + this->_title + ".txt";
+  else
+    filename = *dts.path + this->_title + ".txt";
+  std::ofstream file(filename, std::ios::out);
+  if (!file.is_open()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
   file << this->_content << "\n";
+  if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
   file.close();
+  if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
 }
 
 void POST::writeBinaryBody(RequestDts& dts) {
+  std::string filename;
   if (stat(dts.path->c_str(), &fileinfo) != 0)
     throw((*dts.statusCode) = E_403_FORBIDDEN);
-  std::string filename = *dts.path + this->_title;
+  if ((*dts.path)[dts.path->length() - 1] != '/')
+    filename = *dts.path + "/" + this->_title;
+  else
+    filename = *dts.path + this->_title;
   std::ofstream file(filename.c_str(), std::ios::binary);
   if (!file.is_open()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
   file << this->_content;

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -129,7 +129,7 @@ std::string POST::decodeURL(std::string encoded_string) {
     ++buf_len;
   }
   char* buf = new char[buf_len];
-  bzero(buf, buf_len);
+  std::memset(buf, 0, buf_len);
   char c = 0;
   size_t j = 0;
   for (size_t i = 0; i < len; ++i, ++j) {

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -11,20 +11,15 @@ POST::POST(void) {}
 POST::~POST(void) {}
 
 void POST::doRequest(RequestDts& dts, IResponse& response) {
+#ifndef DEBUG_MSG
   std::cout << " >>>>>>>>>>>>>>> POST\n";
   std::cout << "path: " << *dts.path << "\n";
   std::cout << "body: " << *dts.body << "\n";
   std::cout << "content-type: " << (*dts.headerFields)["content-type"] << "\n";
   std::cout << "content-length: " << (*dts.headerFields)["content-length"]
             << "\n";
-
+#endif
   (void)response;
-  // std::map<std::string, std::string>::iterator it =
-  // (dts.headerFields->begin()); std::map<std::string, std::string>::iterator
-  // end = (dts.headerFields->end()); while (it != end) {
-  //   std::cout << "key: " << it->first << "   value: " << it->second << "\n";
-  //   it++;
-  // }
   this->generateResource(dts);
   response.setStatusCode(E_201_CREATED);
 }
@@ -35,7 +30,6 @@ void POST::generateResource(RequestDts& dts) {
   if (this->_contentType.find(';') != std::string::npos) {
     parsedContent = _contentType.substr(0, _contentType.find(';'));
   }
-  // std::cout << "CONTENT-TYPE: " << parsedContent << "\n";
   if (parsedContent == "application/x-www-form-urlencoded") {
     this->generateUrlEncoded(dts);
   } else if (parsedContent == "multipart/form-data") {
@@ -71,13 +65,26 @@ void POST::generateUrlEncoded(RequestDts& dts) {
 
 void POST::generateMultipart(RequestDts& dts) {
   std::string binBody = (*dts.body).data();
+
+  size_t boundaryEndPos = binBody.find("\r\n");
+  if (boundaryEndPos == std::string::npos)
+    throw((*dts.statusCode) = E_400_BAD_REQUEST);
+  this->_boundary = binBody.substr(0, boundaryEndPos);
+
   size_t filePos = binBody.find("filename=");
   size_t fileEndPos = binBody.find("\r\n", filePos);
   if (filePos == std::string::npos || fileEndPos == std::string::npos)
     throw((*dts.statusCode) = E_400_BAD_REQUEST);
   this->_title = binBody.substr(filePos + 10, fileEndPos - filePos - 11);
-  std::cout << "title: " << this->_title << "\n";
 
+  size_t binStart = (*dts.body).find("\r\n\r\n");
+  size_t boundary2EndPos = (*dts.body).find(this->_boundary, fileEndPos);
+  if (binStart == std::string::npos || boundary2EndPos == std::string::npos)
+    throw((*dts.statusCode) = E_400_BAD_REQUEST);
+
+  this->_content.insert(this->_content.end(),
+                        (*dts.body).begin() + binStart + 4,
+                        (*dts.body).begin() + boundary2EndPos);
   prepareBinaryBody(dts);
 }
 
@@ -97,22 +104,10 @@ void POST::prepareTextBody(RequestDts& dts) {
 void POST::prepareBinaryBody(RequestDts& dts) {
   if (access(dts.path->c_str(), F_OK) < 0)
     throw((*dts.statusCode) = E_403_FORBIDDEN);
-  std::string filename = *dts.path + "tmpTitle";
+  std::string filename = *dts.path + this->_title;
   std::ofstream file(filename.c_str(), std::ios::binary);
-  std::string binBody = (*dts.body).data();
-  size_t boundaryPos = binBody.find("boundary");
 
-  if (boundaryPos == std::string::npos)
-    throw((*dts.statusCode) = E_400_BAD_REQUEST);
-  size_t start =
-      binBody.find("\r\n\r\n", boundaryPos, binBody.find("Content-Type"));
-  size_t end = binBody.rfind("------WebKitFormBoundary");
-  if (start == std::string::npos || end == std::string::npos)
-    throw((*dts.statusCode) = E_400_BAD_REQUEST);
-  start += 4;
-  end -= 2;
-  std::string content = binBody.substr(start, end - start).data();
-  file << content;
+  file << this->_content;
   file.close();
 }
 

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -73,10 +73,13 @@ void POST::generateMultipart(RequestDts& dts) {
 
   size_t filePos = binBody.find("filename=");
   size_t fileEndPos = binBody.find("\r\n", filePos);
-  if (filePos == std::string::npos || fileEndPos == std::string::npos)
-    throw((*dts.statusCode) = E_400_BAD_REQUEST);
+  if (filePos == std::string::npos || fileEndPos == std::string::npos) {
+    this->_title = "Invalid File Name";
+    this->_content = "Invalid File Source";
+    prepareTextBody(dts);
+    return;
+  }
   this->_title = binBody.substr(filePos + 10, fileEndPos - filePos - 11);
-
   size_t binStart = (*dts.body).find("\r\n\r\n");
   size_t boundary2EndPos = (*dts.body).find(this->_boundary, fileEndPos);
   if (binStart == std::string::npos || boundary2EndPos == std::string::npos)

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -22,12 +22,12 @@ void RequestParser::splitLinesByCRLF(RequestDts &dts) {
   size_t pos = 0;
   size_t delimeter = dts.request->find("\r\n");
   while (delimeter != std::string::npos) {
-    std::string chunk = dts.request->substr(pos, delimeter);
+    std::string chunk = dts.request->substr(pos, delimeter - pos);
     dts.linesBuffer->push_back(chunk);
     pos = delimeter + 2;
     delimeter = dts.request->find("\r\n", pos);
     if (delimeter == pos) {
-      *dts.body = &(*dts.request)[pos + 2];
+      *dts.body = dts.request->substr(pos + 2);
       break;
     }
   }
@@ -39,6 +39,7 @@ void RequestParser::parseRequestLine(RequestDts &dts) {
   const std::string &firstLine(dts.linesBuffer->front());
   int delim_cnt = 0;
   size_t pos = firstLine.find(" ", 0);
+
   while (pos != std::string::npos) {
     delim_cnt++;
     pos = firstLine.find(" ", ++pos);
@@ -222,7 +223,7 @@ std::string RequestParser::getFirstTokenOfPath(RequestDts &dts) const {
 // GET /dir/test.txt/ hTML/1.1
 void RequestParser::validatePath(RequestDts &dts) {
   std::string firstToken = getFirstTokenOfPath(dts);
-  if (firstToken == "/health"){
+  if (firstToken == "/health") {
     throw(*dts.statusCode = E_200_OK);
   }
 #ifdef DEBUG_MSG


### PR DESCRIPTION
## POST 요청의 content-type: multipart-form/data 의 구현입니다.
<img width="580" alt="image" src="https://github.com/MyLittleWebServer/webserv/assets/83046766/96698e02-3762-4b19-be85-7fe56af26074">

- client에서 정보를 받아올때 더이상 buffer 뒤에 널값을 붙이지 않습니다.
- POST 에서는 아래와 같은 파싱을 진행합니다.
|- filename 의 value 값을 가져와 파일생성을 합니다.
|- binary 정보가 들어있는 field_value 부분을 (CRLF+4 ~ boundary) content에 넣습니다.

- candidateFields 내부에 transfer-encoding의 헤더필드가 존재하지 않아 원활히 작동하지 않아 해당 필드를 삽입했습니다.
- 마지막으로, conf의 limit_client_body_size를 1000000정도로 잡고 테스트해야 원활히 작동합니다.