### PR TITLE
fix: heap use after free error on timeout

### DIFF
--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -44,6 +44,7 @@ bool Client::checkIfReceiveFinished(ssize_t n) {
 }
 
 void Client::receiveRequest(void) {
+  this->_flag = RECEIVING;
   while (true) {
     ssize_t n = recv(this->_sd, Client::_buf, RECEIVE_LEN, 0);
     if (n <= 0) {

--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -14,7 +14,7 @@ Client::Client() : _flag(START), _sd(0), _method(NULL) {
 }
 
 Client::Client(const uintptr_t sd) {
-  this->_flag = RECEIVING;
+  this->_flag = START;
   this->_sd = sd;
   this->_method = NULL;
   this->_cgi = NULL;
@@ -159,7 +159,7 @@ void Client::makeAndExecuteCgi() {
 }
 
 void Client::clear() {
-  _flag = RECEIVING;
+  _flag = START;
   _recvBuff.clear();
 
   _request.clear();

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -92,7 +92,6 @@ void EventHandler::processRequest(Client &currClient) {
       Kqueue::deleteEvent(this->_currentEvent->ident, EVFILT_TIMER,
                           static_cast<void *>(this->_currentEvent->udata));
     }
-    currClient.setFlag(RECEIVING);
     Kqueue::addEvent(this->_currentEvent->ident, EVFILT_TIMER,
                      EV_ADD | EV_ONESHOT, NOTE_SECONDS, 60,
                      static_cast<void *>(this->_currentEvent->udata));

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -25,14 +25,11 @@ void EventHandler::checkFlags(void) {
     this->_errorFlag = true;
     checkErrorOnSocket();
   }
-  /*
   if (_currentEvent->flags & EV_EOF &&
       Kqueue::getFdType(_currentEvent->ident) == FD_CLIENT) {
     _errorFlag = true;
-    Kqueue::deleteEvent(_currentEvent->ident, EVFILT_TIMER,
-  _currentEvent->udata);
+    disconnectClient(static_cast<Client *>(_currentEvent->udata));
   }
-  */
 }
 
 void EventHandler::checkErrorOnSocket() {
@@ -91,8 +88,13 @@ void EventHandler::branchCondition(void) {
 
 void EventHandler::processRequest(Client &currClient) {
   try {
+    if (currClient.getFlag() == RECEIVING) {
+      Kqueue::deleteEvent(this->_currentEvent->ident, EVFILT_TIMER,
+                          static_cast<void *>(this->_currentEvent->udata));
+    }
+    currClient.setFlag(RECEIVING);
     Kqueue::addEvent(this->_currentEvent->ident, EVFILT_TIMER,
-                     EV_ADD | EV_ONESHOT, 0, 10,
+                     EV_ADD | EV_ONESHOT, NOTE_SECONDS, 60,
                      static_cast<void *>(this->_currentEvent->udata));
     std::cout << "socket descriptor : " << currClient.getSD() << std::endl;
     currClient.receiveRequest();
@@ -106,10 +108,13 @@ void EventHandler::processRequest(Client &currClient) {
       currClient.newHTTPMethod();
       currClient.doRequest();
       currClient.createSuccessResponse();
-      enableEvent(currClient.getSD(), EVFILT_WRITE,
-                  static_cast<void *>(&currClient));
+      Kqueue::disableEvent(currClient.getSD(), EVFILT_READ,
+                           static_cast<void *>(&currClient));
+      Kqueue::enableEvent(currClient.getSD(), EVFILT_WRITE,
+                          static_cast<void *>(&currClient));
     }
   } catch (enum Status &code) {
+    if (currClient.getFlag() == RECEIVING) Kqueue::_eventsToAdd.pop_back();
     currClient.createErrorResponse();
     enableEvent(currClient.getSD(), EVFILT_WRITE,
                 static_cast<void *>(&currClient));
@@ -128,8 +133,10 @@ void EventHandler::processResponse(Client &currClient) {
     disconnectClient(&currClient);
   };
   if (currClient.getFlag() == END_KEEP_ALIVE) {
-    disableEvent(currClient.getSD(), EVFILT_WRITE,
-                 static_cast<void *>(&currClient));
+    Kqueue::disableEvent(currClient.getSD(), EVFILT_WRITE,
+                         static_cast<void *>(&currClient));
+    Kqueue::enableEvent(currClient.getSD(), EVFILT_READ,
+                        static_cast<void *>(&currClient));
     currClient.clear();
     return;
   }


### PR DESCRIPTION
- processRequest 진입 시, 처음이 아니라면 이전에 등록되어 있는 timer 이벤트를 삭제하도록 했습니다.
- 클라이언트 소켓 이벤트를 기다리는 중 클라이언트 측에서 연결을 해제할 시 해당 소켓으로 읽기 이벤트가 발생해하는데, 이 때 EV_EOF 플래그가 참으로 들어오므로 이 때 클라이언트를 연결 해제하도록 하였습니다.