### PR TITLE
fix(EventHandler): fix heap use after free

### DIFF
--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -48,6 +48,7 @@ class Client {
   Response _response;
   IMethod *_method;
   ICGI *_cgi;
+  size_t _lastSentPos;
 
   static char _buf[RECEIVE_LEN];
 

--- a/srcs/clients/response/include/IResponse.hpp
+++ b/srcs/clients/response/include/IResponse.hpp
@@ -22,6 +22,5 @@ class IResponse {
   virtual void setResponseParsed() = 0;
   virtual bool isParsed() = 0;
 
-  virtual void setResponse(std::string response) = 0;
   virtual void clear(void) = 0;
 };

--- a/srcs/clients/response/include/Response.hpp
+++ b/srcs/clients/response/include/Response.hpp
@@ -48,6 +48,5 @@ class Response : public IResponse {
   void setResponseParsed();
   bool isParsed();
 
-  void setResponse(std::string response);
   void clear(void);
 };

--- a/srcs/clients/response/src/Response.cpp
+++ b/srcs/clients/response/src/Response.cpp
@@ -118,8 +118,6 @@ void Response::addBody(const std::string &str) { this->_body += str; }
 
 void Response::setBody(const std::string &str) { this->_body = str; }
 
-void Response::setResponse(std::string response) { this->_response = response; }
-
 void Response::configureErrorPages(RequestDts &dts) {
   IServerConfig &serverConfig = **dts.matchedServer;
 

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -130,6 +130,7 @@ void EventHandler::processResponse(Client &currClient) {
   } catch (std::exception &e) {
     std::cerr << e.what() << '\n';
     disconnectClient(&currClient);
+    return;
   };
   if (currClient.getFlag() == END_KEEP_ALIVE) {
     Kqueue::disableEvent(currClient.getSD(), EVFILT_WRITE,

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -174,8 +174,6 @@ void EventHandler::disconnectClient(Client *client) {
                       static_cast<void *>(client));
   Kqueue::deleteEvent((uintptr_t)client->getSD(), EVFILT_READ,
                       static_cast<void *>(client));
-  // Kqueue::deleteEvent((uintptr_t)client->getSD(), EVFILT_TIMER,
-  //                     static_cast<void *>(client));
   Kqueue::deleteFdSet((uintptr_t)client->getSD(), FD_CLIENT);
 
   std::cout << "Client " << client->getSD() << " disconnected!" << std::endl;


### PR DESCRIPTION
- processResponse에서 예외 catch 시 disconnect이후 리턴하도록 하였습니다.
- 한 번에 send() 되지 않았을 경우 처리 방법을 바꾸었습니다.
  - 멤버변수 Response::_lastSentPos 으로 이전에 보낸 위치를 기억하도록 하여 새로운 문자열 생성을 대체하였습니다.
- Response::setResponse() 를 더 이상 사용하는 곳이 없어 삭제하였습니다.