### PR TITLE
RFC 7230 4. Transfer Encoding

### DIFF
--- a/srcs/clients/candidate_fields/srcs/CandidateFields.cpp
+++ b/srcs/clients/candidate_fields/srcs/CandidateFields.cpp
@@ -62,6 +62,7 @@ void CandidateFields::initCandidateFields() {
   _candidateFields.insert("x-correlation-id");
   _candidateFields.insert("x-csrf-token");
   _candidateFields.insert("x-device-user-agent");
+  _candidateFields.insert("te");
 }
 
 CandidateFields& CandidateFields::getInstance() {

--- a/srcs/clients/request/request_parser/include/RequestParser.hpp
+++ b/srcs/clients/request/request_parser/include/RequestParser.hpp
@@ -45,12 +45,12 @@ class RequestParser : public IRequestParser {
   void checkMethod(RequestDts& dts);
   void checkProtocolVersion(RequestDts& dts);
   void checkRequestUriLimitLength(RequestDts& dts);
-
   void checkContentLenghWithTransferEncoding(RequestDts& dts);
   void checkHeaderLimitSize(RequestDts& dts);
   void checkBodyLimitLength(RequestDts& dts);
   void checkAllowedMethods(RequestDts& dts);
   void checkCgiMethod(RequestDts& dts);
+  void checkTE(RequestDts& dts);
 
  private:
   const std::set<std::string>& _candidateFields;

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -468,6 +468,7 @@ void RequestParser::requestChecker(RequestDts &dts) {
   checkBodyLimitLength(dts);
   checkAllowedMethods(dts);
   checkCgiMethod(dts);
+  checkTE(dts);
 }
 
 /**
@@ -620,4 +621,23 @@ void RequestParser::checkAllowedMethods(RequestDts &dts) {
 void RequestParser::checkCgiMethod(RequestDts &dts) {
   if (*dts.is_cgi && *dts.method != "GET" && *dts.method != "POST")
     throw(*dts.statusCode = E_400_BAD_REQUEST);
+}
+
+/**
+ * @brief checkTE;
+ *
+ * chunked는 항상 구현되어야 하기 때문에 TE 헤더에서 허용되지 않습니다.
+ * TE 헤더에 chunked가 있으면 400 에러를 반환합니다.
+ * 구현되지 않은 인코딩에 대해 501 에러를 반환합니다.
+ *
+ * @param RequestDts HTTP 관련 데이터
+ * @return void
+ * @author middlefitting
+ * @date 2023.07.17
+ */
+void RequestParser::checkTE(RequestDts &dts) {
+  if (ft_trim((*dts.headerFields)["te"]).empty()) return;
+  if ((*dts.headerFields)["te"] == "chunked")
+    throw(*dts.statusCode = E_400_BAD_REQUEST);
+  throw(*dts.statusCode = E_501_NOT_IMPLEMENTED);
 }


### PR DESCRIPTION
## 개요
- RFC 7230 4. Transfer codings 에 따라 프로그램을 개선합니다.
- 이미 RFC에 맞게 구현이 된 부분은 명시하지 않습니다.


## RFC 준수 개선 사항
- [x] 4.3 TE
> 클라이언트는 TE로 “chunked” 전송 코딩 이름을 전송해서는 안 된다.(MUST NOT)

## 기존 개선
- CandidateFields::_candidateFields: te를 추가합니다.


## 기능 구현
- RequestParser::checkTE


## 문서화
- RequestParser::checkTE