### PR TITLE
feat(DELETE): implement delete method

### DIFF
--- a/srcs/clients/method/src/DELETE.cpp
+++ b/srcs/clients/method/src/DELETE.cpp
@@ -5,6 +5,10 @@ DELETE::~DELETE() {}
 
 void DELETE::doRequest(RequestDts& dts, IResponse& response) {
   (void)response;
+  struct stat fileInfo;
+  if (stat(dts.path->c_str(), &fileInfo) != 0)
+    throw(*dts.statusCode = E_404_NOT_FOUND);
+  if (fileInfo.st_mode & S_IFDIR) throw(*dts.statusCode = E_403_FORBIDDEN);
   if (std::remove(dts.path->c_str()) != 0) {
     std::cout << *dts.path << '\n';
     throw(*dts.statusCode = E_404_NOT_FOUND);

--- a/srcs/clients/method/src/DELETE.cpp
+++ b/srcs/clients/method/src/DELETE.cpp
@@ -3,15 +3,19 @@
 DELETE::DELETE() {}
 DELETE::~DELETE() {}
 
-void DELETE::doRequest(RequestDts& dts, IResponse &response) {
+void DELETE::doRequest(RequestDts& dts, IResponse& response) {
   (void)response;
-  if (std::remove(dts.path->c_str()) == false) {
+  if (std::remove(dts.path->c_str()) != 0) {
+    std::cout << *dts.path << '\n';
     throw(*dts.statusCode = E_404_NOT_FOUND);
   }
   *dts.statusCode = E_200_OK;
 }
 
 void DELETE::createSuccessResponse(IResponse& response) {
+  response.addBody("Resource has been successfully deleted.\r\n");
+  response.setHeaderField("Content-Type", "text/plain");
+  response.setHeaderField("Content-Length", itos(response.getBody().size()));
   response.assembleResponse();
   response.setResponseParsed();
 }

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -609,11 +609,12 @@ void RequestParser::checkBodyLimitLength(RequestDts &dts) {
 }
 
 void RequestParser::checkAllowedMethods(RequestDts &dts) {
-  const std::map<std::string, bool> &method_info =
+  const std::map<std::string, bool> &methodInfo =
       (*dts.matchedLocation)->getAllowMethod();
-  std::map<std::string, bool>::const_iterator it =
-      method_info.find(*dts.method);
-  if (it != method_info.end() && it->second == true) return;
+  std::map<std::string, bool>::const_iterator it = methodInfo.find(*dts.method);
+  if ((it != methodInfo.end() && it->second == true) ||
+      (*dts.method == "DELETE" && methodInfo.at("POST") == true))
+    return;
   throw(*dts.statusCode = E_405_METHOD_NOT_ALLOWED);
 }
 


### PR DESCRIPTION
- 매치된 로케이션에서 POST가 가능할 때만 DELETE가 가능하도록 RequestParser::checkAllowedMethod()를 변경하였습니다.
- 경로가 디렉토리일 경우 403 Forbidden으로 처리하였습니다.
- 삭제 성공 시 삭제에 성공했다는 메시지를 페이로드에 담아 응답하도록 하였습니다.