### PR TITLE
feat(POST): add location headerfield into response

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -196,7 +196,7 @@ server {
 		allow_method POST;
 		index youpi.bla;
 		autoindex off;
-		limit_client_body_size 100;
+		limit_client_body_size 10000000;
 	}
 
 	location /directory {

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -123,6 +123,11 @@ void POST::writeBinaryBody(RequestDts& dts) {
 }
 
 void POST::createSuccessResponse(IResponse& response) {
+  response.setHeaderField("Location", "/post_body/" + _title);
+  response.setBody("File has been successfully uploaded.\r\npath: /directory/" +
+                   _title + "\r\n");
+  response.setHeaderField("Content-Type", "text/plain");
+  response.setHeaderField("Content-Length", itos(response.getBody().size()));
   response.assembleResponse();
   response.setResponseParsed();
 }


### PR DESCRIPTION
- POST에 대한 성공 응답 생성 시, Location 헤더 필드에 생성된 파일의 경로를 삽입하였습니다.
- 바디에 포스트에 성공했다는 메시지 및 생성된 파일의 경로를 삽입하였습니다.
- default.conf 의 3000 포트 서버의 post_body 로케이션 블록의 client_limit_body_size 를 1천만 byte로 변경하였습니다.