### PR TITLE
feat(develop): rfc-7231-3-Representations

### DIFF
--- a/srcs/clients/request/request_parser/include/RequestParser.hpp
+++ b/srcs/clients/request/request_parser/include/RequestParser.hpp
@@ -56,6 +56,7 @@ class RequestParser : public IRequestParser {
   void checkAllowedMethods(RequestDts& dts);
   void checkCgiMethod(RequestDts& dts);
   void checkTE(RequestDts& dts);
+  void checkContentType(RequestDts& dts);
 
  private:
   const std::set<std::string>& _candidateFields;

--- a/srcs/clients/request/request_parser/include/RequestParser.hpp
+++ b/srcs/clients/request/request_parser/include/RequestParser.hpp
@@ -38,6 +38,7 @@ class RequestParser : public IRequestParser {
   void validateContentLengthHeader(RequestDts& dts);
   void validateHeaderKey(std::string& key, RequestDts& dts);
   void validateHostHeader(short port, RequestDts& dts);
+  void ValidateContentEncoding(RequestDts& dts);
   void hostHeaderNameCheck(std::string hostName, RequestDts& dts);
   void hostHeaderportCheck(short port, std::string portName, RequestDts& dts);
 

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -752,3 +752,21 @@ void RequestParser::checkTE(RequestDts &dts) {
     throw(*dts.statusCode = E_400_BAD_REQUEST);
   throw(*dts.statusCode = E_501_NOT_IMPLEMENTED);
 }
+
+/**
+ * @brief checkContentType;
+ *
+ * RFC 7231 3.1.1.5 Content-Type (MAY)
+ * POST, PUT 메소드에는 Content-Type이 있어야 합니다.
+ * Content-Type이 없으면 application/octet-stream으로 간주합니다.
+ *
+ * @param RequestDts HTTP 관련 데이터
+ * @return void
+ * @author middlefitting
+ * @date 2023.07.18
+ */
+void RequestParser::checkContentType(RequestDts &dts) {
+  if (!(*dts.headerFields)["content-type"].empty()) return;
+  if (*dts.method == "POST" || *dts.method == "PUT")
+    (*dts.headerFields)["content-type"] = "application/octet-stream";
+}

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -477,6 +477,7 @@ void RequestParser::parseRequest(RequestDts &dts, short port) {
   parseHeaderFields(dts);
   validateContentLengthHeader(dts);
   validateHostHeader(port, dts);
+  ValidateContentEncoding(dts);
   parseContent(dts);
   matchServerConf(port, dts);
   validatePath(dts);
@@ -495,6 +496,7 @@ void RequestParser::requestChecker(RequestDts &dts) {
   checkHeaderLimitSize(dts);
   checkBodyLimitLength(dts);
   checkAllowedMethods(dts);
+  checkContentType(dts);
   checkCgiMethod(dts);
   checkTE(dts);
 }
@@ -769,4 +771,20 @@ void RequestParser::checkContentType(RequestDts &dts) {
   if (!(*dts.headerFields)["content-type"].empty()) return;
   if (*dts.method == "POST" || *dts.method == "PUT")
     (*dts.headerFields)["content-type"] = "application/octet-stream";
+}
+
+/**
+ * @brief ValidateContentEncoding;
+ *
+ * RFC 7231 3.1.2.2 Content Encoding (MAY)
+ * 서버는 인코딩을 지원하지 않기 때문에 해당 헤더가 존재시 415를 반환합니다.
+ *
+ * @param RequestDts HTTP 관련 데이터
+ * @return void
+ * @author middlefitting
+ * @date 2023.07.20
+ */
+void RequestParser::ValidateContentEncoding(RequestDts &dts) {
+  if ((*dts.headerFields)["content-encoding"].empty()) return;
+  throw(*dts.statusCode = E_415_UNSUPPORTED_MEDIA_TYPE);
 }


### PR DESCRIPTION
## 개요
- RFC 7231 3. Representations에 따라 프로그램을 개선합니다.
- 이미 RFC에 맞게 구현이 된 부분은 명시하지 않습니다.


## RFC 준수 개선 사항
- [x] 3.1.1.5 Content-Type
> Content-Type 헤더 필드가 없는 경우 수신자는 “application/octet- stream” ([RFC2046], Section 4.5.1)의 미디어 타입을 가정하거나 데이터를 검토하여 타입을 결정할 수 있다.(MAY)
- [x] 3.1.2.2 Content Encoding
> 원서버는 요청 메시지의 표현에 허용되지 않는 콘텐츠 코딩이 있는 경우 상태 코드 415(Unsupported Media Type)로 응답할 것이다.(MAY)


## 기능 구현
- RequestParser::checkContentType
- RequestParser::ValidateContentEncoding


## 문서화
- RequestParser::checkContentType
- RequestParser::ValidateContentEncoding