### PR TITLE
fix(Utils): fix underflow in ft_trim

### DIFF
--- a/srcs/utils/util/src/Utils.cpp
+++ b/srcs/utils/util/src/Utils.cpp
@@ -50,6 +50,7 @@ std::string ft_trimOWS(std::string &str) {
 }
 
 std::string ft_trim(std::string &str) {
+  if (str.empty()) return str;
   std::string result = str;
   size_t pos = 0;
   while (pos < result.size() && std::isspace(result[pos])) pos++;


### PR DESCRIPTION
- string이 비어있을 경우 바로 리턴하도록 조치하였습니다.