### PR TITLE
refactor(EventHandler): refactor member functions

### DIFF
--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -173,13 +173,15 @@ void Client::clear() {
 }
 
 void Client::setResponseConnection() {
-  if (_request.getHeaderField("connection") == "close")
-    _response.setHeaderField("connection", "close");
-  else
-    _response.setHeaderField("connection", "keep-alive");
+  if (_request.getHeaderField("connection") == "close") {
+    _response.setHeaderField("Connection", "close");
+  } else {
+    _response.setHeaderField("Connection", "keep-alive");
+  }
   _response.assembleResponse();
+  _flag = PROCESS_RESPONSE;
 }
 
 void Client::setConnectionClose() {
-  _request.setHeaderField("connection", "close");
+  _request.setHeaderField("Connection", "close");
 }

--- a/srcs/server/include/EventHandler.hpp
+++ b/srcs/server/include/EventHandler.hpp
@@ -17,16 +17,24 @@ class EventHandler : public Kqueue {
   struct kevent* _currentEvent;
   bool _errorFlag;
 
-  void checkErrorOnSocket(void);
   void acceptClient(void);
-  void disconnectClient(Client* client);
   void registClient(const uintptr_t clientSocket);
-  void processRequest(Client& client);
-  void processResponse(Client& client);
-  void processTimeOut(Client& client);
+  void disconnectClient(Client* client);
+
+  void checkErrorOnSocket(void);
 
   void clientCondtion();
   void cgiCondition();
+
+  void processRequest(Client& client);
+  void handleTimer(Client& client);
+  void enactRequestAndCreateResponse(Client& client);
+  void handleExceptionStatusCode(Client& client);
+
+  void processResponse(Client& client);
+  void validateConnection(Client& client);
+
+  void processTimeOut(Client& client);
 
  public:
   EventHandler(const std::vector<Server*>& serverVector);

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -12,17 +12,19 @@ EventHandler::EventHandler(const std::vector<Server *> &serverVector)
     : _errorFlag(false) {
   for (std::vector<Server *>::const_iterator it = serverVector.begin();
        it != serverVector.end(); ++it) {
-    this->_serverSocketSet.insert((*it)->getSocket());
+    _serverSocketSet.insert((*it)->getSocket());
     delete (*it);
   }
 }
 
 EventHandler::~EventHandler(void) {}
 
+void EventHandler::setCurrentEvent(int i) { _currentEvent = &(_eventList[i]); }
+
 void EventHandler::checkFlags(void) {
-  this->_errorFlag = false;
+  _errorFlag = false;
   if (_currentEvent->flags & EV_ERROR) {
-    this->_errorFlag = true;
+    _errorFlag = true;
     checkErrorOnSocket();
   }
   if (_currentEvent->flags & EV_EOF &&
@@ -32,43 +34,11 @@ void EventHandler::checkFlags(void) {
   }
 }
 
-void EventHandler::checkErrorOnSocket() {
-  if (_serverSocketSet.find(this->_currentEvent->ident) !=
-      this->_serverSocketSet.end())
-    throwWithPerror("server socket error");
-  std::cout << " client socket error" << std::endl;
-  disconnectClient(static_cast<Client *>(this->_currentEvent->udata));
-}
-
-void EventHandler::setCurrentEvent(int i) {
-  this->_currentEvent = &(this->_eventList[i]);
-}
-
-void EventHandler::clientCondtion() {
-  Client &currClient = *(static_cast<Client *>(this->_currentEvent->udata));
-  if (this->_currentEvent->filter == EVFILT_READ) {
-    processRequest(currClient);
-  } else if (this->_currentEvent->filter == EVFILT_WRITE) {
-    processResponse(currClient);
-  } else if (this->_currentEvent->filter == EVFILT_TIMER) {
-    // create timeout response
-    std::cout << "TIMEOUT OCCORRED!!!!\n";
-    processTimeOut(currClient);
-  }
-}
-
-void EventHandler::cgiCondition() {
-  ICGI &cgi = *(static_cast<ICGI *>(_currentEvent->udata));
-  if (_currentEvent->filter == EVFILT_READ) {
-    cgi.waitAndReadCGI();
-  } else if (_currentEvent->filter == EVFILT_WRITE) {
-    cgi.writeCGI();
-  }
-}
-
 void EventHandler::branchCondition(void) {
-  if (this->_errorFlag == true) return;
-  e_fd_type fd_type = Kqueue::getFdType(this->_currentEvent->ident);
+  if (_errorFlag == true) {
+    return;
+  }
+  e_fd_type fd_type = Kqueue::getFdType(_currentEvent->ident);
   switch (fd_type) {
     case FD_SERVER: {
       acceptClient();
@@ -86,81 +56,11 @@ void EventHandler::branchCondition(void) {
   }
 }
 
-void EventHandler::processRequest(Client &currClient) {
-  try {
-    if (currClient.getFlag() == RECEIVING) {
-      Kqueue::deleteEvent(this->_currentEvent->ident, EVFILT_TIMER,
-                          static_cast<void *>(this->_currentEvent->udata));
-    }
-    Kqueue::addEvent(this->_currentEvent->ident, EVFILT_TIMER,
-                     EV_ADD | EV_ONESHOT, NOTE_SECONDS, 60,
-                     static_cast<void *>(this->_currentEvent->udata));
-    std::cout << "socket descriptor : " << currClient.getSD() << std::endl;
-    currClient.receiveRequest();
-    currClient.parseRequest(getBoundPort(_currentEvent));
-    if (currClient.getFlag() != REQUEST_DONE) return;
-    currClient.setFlag(METHOD_SELECT);
-    Kqueue::_eventsToAdd.pop_back();
-    if (currClient.isCgi()) {
-      currClient.makeAndExecuteCgi();
-    } else {
-      currClient.newHTTPMethod();
-      currClient.doRequest();
-      currClient.createSuccessResponse();
-      Kqueue::disableEvent(currClient.getSD(), EVFILT_READ,
-                           static_cast<void *>(&currClient));
-      Kqueue::enableEvent(currClient.getSD(), EVFILT_WRITE,
-                          static_cast<void *>(&currClient));
-    }
-  } catch (enum Status &code) {
-    if (currClient.getFlag() == RECEIVING) Kqueue::_eventsToAdd.pop_back();
-    currClient.createExceptionResponse();
-    enableEvent(currClient.getSD(), EVFILT_WRITE,
-                static_cast<void *>(&currClient));
-  } catch (std::exception &e) {
-    disconnectClient(&currClient);
-    std::cerr << e.what() << '\n';
-    return;
-  };
-}
-
-void EventHandler::processResponse(Client &currClient) {
-  if (currClient.getFlag() != PROCESS_RESPONSE) {
-    currClient.setResponseConnection();
-    currClient.setFlag(PROCESS_RESPONSE);
-  }
-  try {
-    currClient.sendResponse();
-  } catch (std::exception &e) {
-    std::cerr << e.what() << '\n';
-    disconnectClient(&currClient);
-    return;
-  };
-  if (currClient.getFlag() == END_KEEP_ALIVE) {
-    Kqueue::disableEvent(currClient.getSD(), EVFILT_WRITE,
-                         static_cast<void *>(&currClient));
-    Kqueue::enableEvent(currClient.getSD(), EVFILT_READ,
-                        static_cast<void *>(&currClient));
-    currClient.clear();
-    return;
-  }
-  if (currClient.getFlag() == END_CLOSE) {
-    disconnectClient(&currClient);
-    return;
-  }
-}
-
-void EventHandler::processTimeOut(Client &currClient) {
-  currClient.setConnectionClose();
-  currClient.createExceptionResponse(E_408_REQUEST_TIMEOUT);
-  enableEvent(currClient.getSD(), EVFILT_WRITE,
-              static_cast<void *>(&currClient));
-}
-
 void EventHandler::acceptClient() {
   uintptr_t clientSocket;
-  if ((clientSocket = accept(this->_currentEvent->ident, NULL, NULL)) == -1)
+  if ((clientSocket = accept(_currentEvent->ident, NULL, NULL)) == -1) {
     throwWithPerror("accept() error\n" + std::string(strerror(errno)));
+  }
   std::cout << "accept ... : " << clientSocket << std::endl;
   fcntl(clientSocket, F_SETFL, O_NONBLOCK);
   registClient(clientSocket);
@@ -184,4 +84,118 @@ void EventHandler::disconnectClient(Client *client) {
 
   std::cout << "Client " << client->getSD() << " disconnected!" << std::endl;
   delete client;
+}
+
+void EventHandler::checkErrorOnSocket() {
+  if (_serverSocketSet.find(_currentEvent->ident) != _serverSocketSet.end()) {
+    throwWithPerror("server socket error");
+  }
+  std::cout << " client socket error" << std::endl;
+  disconnectClient(static_cast<Client *>(_currentEvent->udata));
+}
+
+void EventHandler::clientCondtion() {
+  Client &currClient = *(static_cast<Client *>(_currentEvent->udata));
+  if (_currentEvent->filter == EVFILT_READ) {
+    processRequest(currClient);
+  } else if (_currentEvent->filter == EVFILT_WRITE) {
+    processResponse(currClient);
+  } else if (_currentEvent->filter == EVFILT_TIMER) {
+    processTimeOut(currClient);
+  }
+}
+
+void EventHandler::cgiCondition() {
+  ICGI &cgi = *(static_cast<ICGI *>(_currentEvent->udata));
+  if (_currentEvent->filter == EVFILT_READ) {
+    cgi.waitAndReadCGI();
+  } else if (_currentEvent->filter == EVFILT_WRITE) {
+    cgi.writeCGI();
+  }
+}
+
+void EventHandler::processRequest(Client &currClient) {
+  try {
+    handleTimer(currClient);
+    std::cout << "socket descriptor : " << currClient.getSD() << std::endl;
+    currClient.receiveRequest();
+    currClient.parseRequest(getBoundPort(_currentEvent));
+    if (currClient.getFlag() == RECEIVING) {
+      return;
+    }
+    currClient.setFlag(METHOD_SELECT);
+    Kqueue::_eventsToAdd.pop_back();
+    if (currClient.isCgi()) {
+      currClient.makeAndExecuteCgi();
+    } else {
+      enactRequestAndCreateResponse(currClient);
+    }
+  } catch (enum Status &code) {
+    handleExceptionStatusCode(currClient);
+  } catch (std::exception &e) {
+    disconnectClient(&currClient);
+    std::cerr << e.what() << '\n';
+    return;
+  }
+}
+
+void EventHandler::handleTimer(Client &currClient) {
+  if (currClient.getFlag() == RECEIVING) {
+    Kqueue::deleteEvent(_currentEvent->ident, EVFILT_TIMER,
+                        static_cast<void *>(_currentEvent->udata));
+  }
+  Kqueue::addEvent(_currentEvent->ident, EVFILT_TIMER, EV_ADD | EV_ONESHOT,
+                   NOTE_SECONDS, 60, static_cast<void *>(_currentEvent->udata));
+}
+
+void EventHandler::enactRequestAndCreateResponse(Client &currClient) {
+  currClient.newHTTPMethod();
+  currClient.doRequest();
+  currClient.createSuccessResponse();
+  Kqueue::disableEvent(currClient.getSD(), EVFILT_READ,
+                       static_cast<void *>(&currClient));
+  Kqueue::enableEvent(currClient.getSD(), EVFILT_WRITE,
+                      static_cast<void *>(&currClient));
+}
+
+void EventHandler::handleExceptionStatusCode(Client &currClient) {
+  if (currClient.getFlag() == RECEIVING) {
+    Kqueue::_eventsToAdd.pop_back();
+  }
+  currClient.createExceptionResponse();
+  enableEvent(currClient.getSD(), EVFILT_WRITE,
+              static_cast<void *>(&currClient));
+}
+
+void EventHandler::processResponse(Client &currClient) {
+  if (currClient.getFlag() != PROCESS_RESPONSE) {
+    currClient.setResponseConnection();
+  }
+  try {
+    currClient.sendResponse();
+  } catch (std::exception &e) {
+    std::cerr << e.what() << '\n';
+    disconnectClient(&currClient);
+    return;
+  }
+  validateConnection(currClient);
+}
+
+void EventHandler::validateConnection(Client &currClient) {
+  if (currClient.getFlag() == END_KEEP_ALIVE) {
+    Kqueue::disableEvent(currClient.getSD(), EVFILT_WRITE,
+                         static_cast<void *>(&currClient));
+    Kqueue::enableEvent(currClient.getSD(), EVFILT_READ,
+                        static_cast<void *>(&currClient));
+    currClient.clear();
+  } else if (currClient.getFlag() == END_CLOSE) {
+    disconnectClient(&currClient);
+  }
+}
+
+void EventHandler::processTimeOut(Client &currClient) {
+  currClient.setConnectionClose();
+  currClient.createExceptionResponse(E_408_REQUEST_TIMEOUT);
+  enableEvent(currClient.getSD(), EVFILT_WRITE,
+              static_cast<void *>(&currClient));
 }


### PR DESCRIPTION
- EventHandler 클래스의 멤버 함수를 리팩토링 하였습니다.
- 코드 플로우에 맞게 함수 순서를 변경하였습니다.
- Client::_flag 상태 변경을 Client::setResponseConnection() 안에서 해주도록 변경하였습니다.