### PR TITLE
refactor(POST): remove 'this' and some minor changes

### DIFF
--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -24,7 +24,7 @@ class POST : public IMethod {
   void createSuccessResponse(IResponse& response);
   void generateUrlEncoded(RequestDts& dts);
   void generateMultipart(RequestDts& dts);
-  void writeTextBody(RequestDts& dts);
+  void writeTextBody(RequestDts& dts, std::string mimeType);
   void writeBinaryBody(RequestDts& dts);
 
   std::string decodeURL(std::string encoded_string);

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -17,7 +17,6 @@ void POST::doRequest(RequestDts& dts, IResponse& response) {
   std::cout << "content-type: " << (*dts.headerFields)["content-type"] << "\n";
   std::cout << "content-length: " << (*dts.headerFields)["content-length"] << "\n";
 #endif
-  (void)response;
   if (*dts.body == "") throw(*dts.statusCode = E_204_NO_CONTENT);
   generateResource(dts);
   response.setStatusCode(E_201_CREATED);

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -15,24 +15,23 @@ void POST::doRequest(RequestDts& dts, IResponse& response) {
   std::cout << " >>>>>>>>>>>>>>> POST\n";
   std::cout << "path: " << *dts.path << "\n";
   std::cout << "content-type: " << (*dts.headerFields)["content-type"] << "\n";
-  std::cout << "content-length: " << (*dts.headerFields)["content-length"]
-            << "\n";
+  std::cout << "content-length: " << (*dts.headerFields)["content-length"] << "\n";
 #endif
   (void)response;
-  this->generateResource(dts);
+  if (*dts.body == "") throw(*dts.statusCode = E_204_NO_CONTENT);
+  generateResource(dts);
   response.setStatusCode(E_201_CREATED);
 }
 
 void POST::generateResource(RequestDts& dts) {
-  this->_contentType = (*dts.headerFields)["content-type"].c_str();
-  std::string parsedContent = this->_contentType;
-  if (this->_contentType.find(';') != std::string::npos) {
+  std::string parsedContent = _contentType = (*dts.headerFields)["content-type"].c_str();
+  if (_contentType.find(';') != std::string::npos) {
     parsedContent = _contentType.substr(0, _contentType.find(';'));
   }
   if (parsedContent == "application/x-www-form-urlencoded") {
-    this->generateUrlEncoded(dts);
+    generateUrlEncoded(dts);
   } else if (parsedContent == "multipart/form-data") {
-    this->generateMultipart(dts);
+    generateMultipart(dts);
   } else {
     std::string mimeType = "txt"; // default mime type as plain text
     MimeTypesConfig& mime = dynamic_cast<MimeTypesConfig&>(
@@ -40,8 +39,8 @@ void POST::generateResource(RequestDts& dts) {
 
     try {
       std::string mimeType = mime.getVariable(parsedContent);
-      this->_content = (*dts.body);
-      this->_title = "file";
+      _content = (*dts.body);
+      _title = "file";
       writeTextBody(dts, mimeType);
     }
     catch (ExceptionThrower::InvalidConfigException& e) {
@@ -51,10 +50,8 @@ void POST::generateResource(RequestDts& dts) {
 }
 
 void POST::generateUrlEncoded(RequestDts& dts) {
-  std::cout << "rawBody: " << *dts.body << "\n";
   std::string decodedBody = decodeURL(*dts.body);
 
-  std::cout << "decodedBody: " << decodedBody << "\n";
   if (decodedBody.find("title") == std::string::npos ||
       decodedBody.find("content") == std::string::npos)
     throw(*dts.statusCode = E_400_BAD_REQUEST);
@@ -64,13 +61,12 @@ void POST::generateUrlEncoded(RequestDts& dts) {
   if (andPos == std::string::npos || equalPos1 == std::string::npos) {
     throw(*dts.statusCode = E_400_BAD_REQUEST);
   }
-  this->_title = decodedBody.substr(equalPos1 + 1, andPos - equalPos1 - 1);
-  decodedBody = decodedBody.substr(andPos + 1);
-  size_t equalPos2 = decodedBody.find('=');
-  this->_content = decodedBody.substr(equalPos2 + 1);
+  _title = decodedBody.substr(equalPos1 + 1, andPos - equalPos1 - 1);
+  size_t equalPos2 = decodedBody.find('=', andPos + 1);
+  _content = decodedBody.substr(equalPos2 + 1);
 #ifdef DEBUG_MSG
-  std::cout << "title: " << this->_title << "\n";
-  std::cout << "content: " << this->_content << "\n";
+  std::cout << "title: " << _title << "\n";
+  std::cout << "content: " << _content << "\n";
   std::cout << "path: " << *dts.path << "\n";
 #endif
   writeTextBody(dts, "txt");
@@ -82,39 +78,39 @@ void POST::generateMultipart(RequestDts& dts) {
   size_t boundaryEndPos = binBody.find("\r\n");
   if (boundaryEndPos == std::string::npos)
     throw((*dts.statusCode) = E_400_BAD_REQUEST);
-  this->_boundary = binBody.substr(0, boundaryEndPos);
+  _boundary = binBody.substr(0, boundaryEndPos);
 
   while (true) {
     std::string binBody = (*dts.body).data();
     size_t filePos = binBody.find("filename=\"");
     size_t fileEndPos = binBody.find('\"', filePos + 11);
     if (filePos == std::string::npos || fileEndPos == std::string::npos) {
-      this->_title = "Unsupported File Name";
-      this->_content = "Unsupported File Source";
+      _title = "Unsupported File Name";
+      _content = "Unsupported File Source";
       writeTextBody(dts, "txt");
       return;
     }
-    this->_title = binBody.substr(filePos + 10, fileEndPos - filePos - 10);
+    _title = binBody.substr(filePos + 10, fileEndPos - filePos - 10);
     size_t binStart = (*dts.body).find("\r\n\r\n");
-    size_t boundary2EndPos = (*dts.body).find(this->_boundary, fileEndPos);
+    size_t boundary2EndPos = (*dts.body).find(_boundary, fileEndPos);
     if (binStart == std::string::npos || boundary2EndPos == std::string::npos)
       throw((*dts.statusCode) = E_400_BAD_REQUEST);
-    this->_content.insert(this->_content.end(),
+    _content.insert(_content.end(),
                           (*dts.body).begin() + binStart + 4,
                           (*dts.body).begin() + boundary2EndPos);
     writeBinaryBody(dts);
     size_t isEOFCRLF = (*dts.body).find("\r\n", boundary2EndPos);
     std::string isEOF =
         (*dts.body).substr(boundary2EndPos, isEOFCRLF - boundary2EndPos);
-    if (isEOF == this->_boundary + "--") {
-      this->_title.clear();
-      this->_content.clear();
+    if (isEOF == _boundary + "--") {
+      _title.clear();
+      _content.clear();
       (*dts.body).clear();
       return;
     }
     (*dts.body) = (*dts.body).substr(boundary2EndPos);
-    this->_title.clear();
-    this->_content.clear();
+    _title.clear();
+    _content.clear();
   }
 }
 
@@ -123,17 +119,17 @@ void POST::writeTextBody(RequestDts& dts, std::string mimeType) {
   if (stat(dts.path->c_str(), &fileinfo) != 0)
     throw((*dts.statusCode) = E_403_FORBIDDEN);
   if ((*dts.path)[dts.path->length() - 1] != '/')
-    filename = *dts.path + "/" + this->_title + "." + mimeType;
+    filename = *dts.path + "/" + _title + "." + mimeType;
   else
-    filename = *dts.path + this->_title + "." + mimeType;
+    filename = *dts.path + _title + "." + mimeType;
   std::ofstream file(filename, std::ios::out);
   if (!file.is_open()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
-  file << this->_content << "\n";
+  file << _content << "\n";
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
   file.close();
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
-  this->_title.clear();
-  this->_content.clear();
+  _title.clear();
+  _content.clear();
 }
 
 void POST::writeBinaryBody(RequestDts& dts) {
@@ -141,12 +137,12 @@ void POST::writeBinaryBody(RequestDts& dts) {
   if (stat(dts.path->c_str(), &fileinfo) != 0)
     throw((*dts.statusCode) = E_403_FORBIDDEN);
   if ((*dts.path)[dts.path->length() - 1] != '/')
-    filename = *dts.path + "/" + this->_title;
+    filename = *dts.path + "/" + _title;
   else
-    filename = *dts.path + this->_title;
+    filename = *dts.path + _title;
   std::ofstream file(filename.c_str(), std::ios::binary);
   if (!file.is_open()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
-  file << this->_content;
+  file << _content;
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
   file.close();
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## Refactor POST
- POST 를 리팩토링하는 작업을 진행했습니다.
- 주요변경점으로는 하기와 같습니다.
|- convention에 맞게 "this->" 를 삭제했습니다.
|- POST.hpp 파일에 누락되었던 writeTextBody 메소드의 mimeType 인자를 넣었습니다.
|- 그 외로 필요없는 부분들을 삭제하거나 축약시키는 과정을 진행했습니다.