### PR TITLE
feat(post): create file w/ unique ID

### DIFF
--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -11,6 +11,7 @@ class POST : public IMethod {
   std::string _boundary;
   std::string _title;
   std::string _content;
+  std::string _randName;
 
   struct stat fileinfo;
 
@@ -29,8 +30,7 @@ class POST : public IMethod {
 
   std::string decodeURL(std::string encoded_string);
 
-  std::string makeRandomNameFile(RequestDts& dts);
-  std::string makeRandomName(int urandFd);
+  std::string makeRandomFileName(RequestDts& dts);
 
   // std::string validateContentType();
 };

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -29,6 +29,9 @@ class POST : public IMethod {
 
   std::string decodeURL(std::string encoded_string);
 
+  std::string makeRandomNameFile(RequestDts& dts);
+  std::string makeRandomName(int urandFd);
+
   // std::string validateContentType();
 };
 

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -204,7 +204,6 @@ std::string POST::decodeURL(std::string encoded_string) {
 }
 
 std::string POST::makeRandomFileName(RequestDts& dts) {
-  (void)dts;
   std::string charset =
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   std::string result;

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -40,7 +40,7 @@ void POST::generateResource(RequestDts& dts) {
   } else if (parsedContent == "multipart/form-data") {
     generateMultipart(dts);
   } else {
-    std::string mimeType = "txt";  // default mime type as plain text
+    std::string mimeType = "bin";
     MimeTypesConfig& mime = dynamic_cast<MimeTypesConfig&>(
         Config::getInstance().getMimeTypesConfig());
     try {
@@ -204,24 +204,17 @@ std::string POST::decodeURL(std::string encoded_string) {
 }
 
 std::string POST::makeRandomFileName(RequestDts& dts) {
-  const char* charset = "abcdefghijklmnopqrstuvwxyz0123456789";
-  std::string filename;
-  unsigned int buf[8];
-  char concat_str[9];
-  int i;
-  int urandFd;
+  (void)dts;
+  std::string charset =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  std::string result;
+  std::srand(std::time(0));
 
-  std::memset(concat_str, 0, sizeof(concat_str));
-  urandFd = open("/dev/urandom", O_RDONLY);
-  if (urandFd == -1) {
-    throw(*dts.statusCode = E_500_INTERNAL_SERVER_ERROR);
-  }
-  read(urandFd, buf, sizeof(buf));
-  i = 0;
-  while (i < 8) {
-    concat_str[i] = charset[buf[i] % 36];
-    i++;
-  }
-  filename = std::string(concat_str);
-  return filename;
+  for (int i = 0; i < 8; ++i)
+    result.push_back(charset[std::rand() % charset.size()]);
+
+  if (access(result.c_str(), F_OK) == 0)
+    throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
+
+  return result;
 }

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -213,7 +213,7 @@ std::string POST::makeRandomFileName(RequestDts& dts) {
     result.push_back(charset[std::rand() % charset.size()]);
 
   if (access(result.c_str(), F_OK) == 0)
-    throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
+    throw((*dts.statusCode) = E_409_CONFLICT);
 
   return result;
 }

--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -29,17 +29,22 @@ void POST::doRequest(RequestDts& dts, IResponse& response) {
 }
 
 void POST::generateResource(RequestDts& dts) {
+  std::string parsedContent;
   _contentType = (*dts.headerFields)["content-type"].c_str();
-  if (_contentType == "application/x-www-form-urlencoded") {
+  parsedContent = _contentType;
+  if (_contentType.find(';') != std::string::npos) {
+    parsedContent = _contentType.substr(0, _contentType.find(';'));
+  }
+  if (parsedContent == "application/x-www-form-urlencoded") {
     generateUrlEncoded(dts);
-  } else if (_contentType == "multipart/form-data") {
+  } else if (parsedContent == "multipart/form-data") {
     generateMultipart(dts);
   } else {
     std::string mimeType = "txt";  // default mime type as plain text
     MimeTypesConfig& mime = dynamic_cast<MimeTypesConfig&>(
         Config::getInstance().getMimeTypesConfig());
     try {
-      std::string mimeType = mime.getVariable(_contentType);
+      std::string mimeType = mime.getVariable(parsedContent);
       _content = (*dts.body);
       _title = makeRandomFileName(dts);
       writeTextBody(dts, mimeType);


### PR DESCRIPTION
## 파일명이 정의되지 않은 파일에 대해, unique id를 생성하여 파일이름으로 쓸 수 있도록 했습니다.  
- url-encoded 에서 title의 key값이 비어있는 경우

https://github.com/MyLittleWebServer/webserv/assets/83046766/5f0e5625-d1f7-40b0-bc4f-1ed49cec70ef

- multipart-form/data 에서 filename의 값이 비어있는 경우

```
    if (_title == "") {
      _title = makeRandomFileName(dts);
    }
```
- plain/text 에서 'file' 이름을 정의를 하게되어, 다수의 POST 요청에 대해 멱등성을 만족하지 않아야 하는데, 같은 이름의 파일에 대응하다 보니, 메소드 기능에 대응하지 않음

https://github.com/MyLittleWebServer/webserv/assets/83046766/83b7158e-312c-4516-8766-44ed4343663a

----------------------------------------------------------------------------------------------
추후, PUT 요청에서 더 개선시킬 여지가 생긴다면 수정하겠습니다.