### PR TITLE
fix: change SESSION_TIMER value

### DIFF
--- a/srcs/server/include/Kqueue.hpp
+++ b/srcs/server/include/Kqueue.hpp
@@ -4,7 +4,6 @@
 #include <sys/event.h>
 
 #include <iostream>
-#include <limits>
 #include <map>
 #include <vector>
 

--- a/srcs/server/include/Kqueue.hpp
+++ b/srcs/server/include/Kqueue.hpp
@@ -4,6 +4,7 @@
 #include <sys/event.h>
 
 #include <iostream>
+#include <limits>
 #include <map>
 #include <vector>
 
@@ -28,7 +29,7 @@ typedef enum {
   FD_CGI,
 } e_fd_type;
 
-typedef enum { SESSION_TIMER } e_timer_type;
+typedef enum { SESSION_TIMER = 2147483647 } e_timer_type;
 
 /**
  * @brief Kqueue class : kevent와 FD를 관리하는 클래스입니다.

--- a/srcs/server/include/Kqueue.hpp
+++ b/srcs/server/include/Kqueue.hpp
@@ -28,7 +28,7 @@ typedef enum {
   FD_CGI,
 } e_fd_type;
 
-typedef enum { SESSION_TIMER = 2147483647 } e_timer_type;
+typedef enum { SESSION_TIMER = 8192 } e_timer_type;
 
 /**
  * @brief Kqueue class : kevent와 FD를 관리하는 클래스입니다.


### PR DESCRIPTION
0번 fd를 사용하지 않을 것 같아서, 지우고 올렸었는데.

CGI에서 참조를 할 것 같아서 급하게 수정합니다.

---

FD_ISSET 함수는 정수 형태의 파일 디스크립터를 매개변수로 받습니다. 이 매개변수의 범위는 시스템에서 지원하는 파일 디스크립터의 최대값까지입니다. POSIX 호환 시스템에서는 ulimit -n 명령을 통해 확인할 수 있으며, 이 값은 시스템 설정에 의해 달라질 수 있습니다.

일단은 8192로 변경하였습니다.

<img width="386" alt="image" src="https://github.com/MyLittleWebServer/webserv/assets/85754295/166cb989-5d4f-4a06-a2a8-2f89a5fd0c40">


---

발생상황 : SESSION_TIMER = 2147483647

너무 큰값이 들어오면 getFDType을 확인하려던 도중 터지는것을 확인하였습니다. 

<img width="1238" alt="image" src="https://github.com/MyLittleWebServer/webserv/assets/85754295/bc2e7ed6-1bd7-403b-827f-a94b20a439f1">


아래는 webserv의 pid상태를 찍어둔 스크린샷입니다.

---

<img width="817" alt="image" src="https://github.com/MyLittleWebServer/webserv/assets/85754295/19266d9a-8f36-4f6d-ad80-da077214ae63">
