### PR TITLE
feat: session improve session

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -178,6 +178,7 @@ server {
 	cgi          .cgi;
 	request_timeout 10s;
 	keepalive_timeout 10s;
+	session      on;
 
 	location / {
 			root /tests/html/;

--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -74,6 +74,8 @@ class Client {
   int _requestTimeOutLimit;
   int _requestTimeOutUnit;
 
+  bool _sessionConfig;
+
   static char _buf[RECEIVE_LEN];
 
   bool checkIfReceiveFinished(ssize_t n);
@@ -120,7 +122,8 @@ class Client {
   int getRequestTimeOutLimit() const;
   int getRequestTimeOutUnit() const;
 
-  bool manageSession(RequestDts &dts);
+  void initSessionConfig(short serverPort);
+  bool getSessionConfig() const;
 
   class RecvFailException : public std::exception {
    public:

--- a/srcs/clients/client/include/Client.hpp
+++ b/srcs/clients/client/include/Client.hpp
@@ -74,8 +74,6 @@ class Client {
   int _requestTimeOutLimit;
   int _requestTimeOutUnit;
 
-  bool _sessionConfig;
-
   static char _buf[RECEIVE_LEN];
 
   bool checkIfReceiveFinished(ssize_t n);
@@ -121,9 +119,6 @@ class Client {
   int getKeepAliveTimeOutUnit() const;
   int getRequestTimeOutLimit() const;
   int getRequestTimeOutUnit() const;
-
-  void initSessionConfig(short serverPort);
-  bool getSessionConfig() const;
 
   class RecvFailException : public std::exception {
    public:

--- a/srcs/clients/client/src/Client.cpp
+++ b/srcs/clients/client/src/Client.cpp
@@ -8,7 +8,6 @@
 #include "Kqueue.hpp"
 #include "OPTIONS.hpp"
 #include "POST.hpp"
-#include "Session.hpp"
 #include "PUT.hpp"
 #include "Utils.hpp"
 

--- a/srcs/clients/method/include/POST.hpp
+++ b/srcs/clients/method/include/POST.hpp
@@ -32,7 +32,8 @@ class POST : public IMethod {
 
   std::string makeRandomFileName(RequestDts& dts);
 
-  // std::string validateContentType();
+  bool getSpecificEndpoint(RequestDts& dts, IResponse& response);
+
  private:
   void handlePath(RequestDts& dts, IResponse& response);
   void login(RequestDts& dts, IResponse& response, Session& session);

--- a/srcs/clients/request/include/Request.hpp
+++ b/srcs/clients/request/include/Request.hpp
@@ -20,6 +20,7 @@ class Request : public IRequest {
   bool _isParsed;
   bool _is_cgi;
   bool _is_expect_100;
+  bool _is_session;
 
   size_t _contentLength;
 
@@ -72,6 +73,7 @@ class Request : public IRequest {
   const bool &isParsed(void) const;
   const bool &isCgi(void) const;
   const bool &isExpect100(void) const;
+  const bool &isSession(void) const;
 
   void clear(void);
 };

--- a/srcs/clients/request/request_parser/include/IRequestParser.hpp
+++ b/srcs/clients/request/request_parser/include/IRequestParser.hpp
@@ -31,6 +31,7 @@ typedef struct RequestDts {
   bool* isParsed;
   bool* is_cgi;
   bool* is_expect_100;
+  bool* is_session;
   unsigned long* contentLength;
 } RequestDts;
 

--- a/srcs/clients/request/request_parser/include/RequestParser.hpp
+++ b/srcs/clients/request/request_parser/include/RequestParser.hpp
@@ -19,6 +19,7 @@ class RequestParser : public IRequestParser {
   void parseHeaderFields(RequestDts& dts);
   void parseCookie(RequestDts& dts);
   void parseCgi(RequestDts& dts);
+  void parseSessionConfig(RequestDts& dts);
   void parseContent(RequestDts& dts);
   void parseContentLength(RequestDts& dts);
   void parseTransferEncoding(RequestDts& dts);

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -420,6 +420,10 @@ void RequestParser::parseCgi(RequestDts &dts) {
   *dts.cgi_path = cgiPath;
 }
 
+void RequestParser::parseSessionConfig(RequestDts &dts) {
+  if ((*dts.matchedServer)->getSessionConfig() == "on") *dts.is_session = true;
+}
+
 /**
  * @brief validateHeaderKey;
  *
@@ -514,6 +518,7 @@ void RequestParser::parseRequest(RequestDts &dts, short port) {
   matchServerConf(port, dts);
   validatePath(dts);
   parseCgi(dts);
+  parseSessionConfig(dts);
   requestChecker(dts);
 }
 

--- a/srcs/clients/request/src/Request.cpp
+++ b/srcs/clients/request/src/Request.cpp
@@ -40,6 +40,7 @@ Request &Request::operator=(const Request &src) {
     _isParsed = src._isParsed;
     _contentLength = src._contentLength;
     _is_cgi = src._is_cgi;
+    _is_session = src._is_session;
     _originalPath = src._originalPath;
     _is_expect_100 = src._is_expect_100;
   }
@@ -51,6 +52,7 @@ void Request::initMember() {
   _isParsed = false;
   _is_cgi = false;
   _is_expect_100 = false;
+  _is_session = false;
 
   _contentLength = 0;
 
@@ -76,6 +78,7 @@ void Request::initMember() {
 void Request::initDts() {
   _request_parser_dts.isParsed = &_isParsed;
   _request_parser_dts.is_cgi = &_is_cgi;
+  _request_parser_dts.is_session = &_is_session;
 
   _request_parser_dts.contentLength = &_contentLength;
 
@@ -157,6 +160,8 @@ IServerConfig *Request::getMatchedServer(void) const {
 const bool &Request::isParsed() const { return _isParsed; }
 
 const bool &Request::isCgi() const { return _is_cgi; }
+
+const bool &Request::isSession() const { return _is_session; }
 
 std::ostream &operator<<(std::ostream &os, const Request &request) {
   os << request.getMethod() << request.getRequest() << request.getPath()

--- a/srcs/config/child_config/server_config/include/IServerConfig.hpp
+++ b/srcs/config/child_config/server_config/include/IServerConfig.hpp
@@ -18,6 +18,7 @@ class IServerConfig : public IChildConfig {
   const virtual std::string& getAccessLog() = 0;
   const virtual std::string& getRoot() = 0;
   const virtual std::string& getCgi() = 0;
+  const virtual std::string& getSessionConfig() = 0;
   const virtual std::string& getRequestTimeOut() = 0;
   const virtual std::string& getKeepAliveTimeOut() = 0;
 };

--- a/srcs/config/child_config/server_config/include/ServerConfig.hpp
+++ b/srcs/config/child_config/server_config/include/ServerConfig.hpp
@@ -43,6 +43,7 @@ class ServerConfig : public IServerConfig {
   const std::string& getAccessLog();
   const std::string& getRoot();
   const std::string& getCgi();
+  const std::string& getSessionConfig();
   const virtual std::string& getRequestTimeOut();
   const virtual std::string& getKeepAliveTimeOut();
 };

--- a/srcs/config/child_config/server_config/include/ServerConfig.hpp
+++ b/srcs/config/child_config/server_config/include/ServerConfig.hpp
@@ -23,6 +23,7 @@ class ServerConfig : public IServerConfig {
   static const std::string CGI;
   static const std::string KEEPALIVE_TIMEOUT;
   static const std::string REQUEST_TIMEOUT;
+  static const std::string SESSION;
 
  public:
   ServerConfig();

--- a/srcs/config/child_config/server_config/src/ServerConfig.cpp
+++ b/srcs/config/child_config/server_config/src/ServerConfig.cpp
@@ -9,6 +9,7 @@ const std::string ServerConfig::ROOT = "html";
 const std::string ServerConfig::CGI = ".bla";
 const std::string ServerConfig::KEEPALIVE_TIMEOUT = "75s";
 const std::string ServerConfig::REQUEST_TIMEOUT = "60s";
+const std::string ServerConfig::SESSION = "off";
 
 ServerConfig::ServerConfig() {
   _data.insert(std::pair<std::string, std::string>("server_name", SERVER_NAME));
@@ -21,6 +22,7 @@ ServerConfig::ServerConfig() {
                                                    KEEPALIVE_TIMEOUT));
   _data.insert(
       std::pair<std::string, std::string>("request_timeout", REQUEST_TIMEOUT));
+  _data.insert(std::pair<std::string, std::string>("session", SESSION));
 }
 
 ServerConfig::~ServerConfig() {
@@ -94,6 +96,10 @@ const std::string& ServerConfig::getRequestTimeOut() {
 
 const std::string& ServerConfig::getKeepAliveTimeOut() {
   return getVariable("keepalive_timeout");
+}
+
+const std::string& ServerConfig::getKeepAliveTimeOut() {
+  return getVariable("session");
 }
 
 const std::string& ServerConfig::getRoot() { return getVariable("root"); }

--- a/srcs/config/child_config/server_config/src/ServerConfig.cpp
+++ b/srcs/config/child_config/server_config/src/ServerConfig.cpp
@@ -98,10 +98,10 @@ const std::string& ServerConfig::getKeepAliveTimeOut() {
   return getVariable("keepalive_timeout");
 }
 
-const std::string& ServerConfig::getKeepAliveTimeOut() {
-  return getVariable("session");
-}
-
 const std::string& ServerConfig::getRoot() { return getVariable("root"); }
 
 const std::string& ServerConfig::getCgi() { return getVariable("cgi"); }
+
+const std::string& ServerConfig::getSessionConfig() {
+  return getVariable("session");
+}


### PR DESCRIPTION
- #183 
- 요청이 들어올 때 마다 session을 해당 서버 conf를 순회하여 찾는것이 비효율적일것 같아 dts로 등록하였습니다.
- request parser에 넣어 dts에 bool값으로 접근하게 합니다.
- post에서 session conf를 확인하기 위해서 특정 엔드포인트로 분기하는 함수를 추가했습니다.