### PR TITLE
fix: delete timer event when disconnect client

### DIFF
--- a/srcs/clients/method/src/POST.cpp
+++ b/srcs/clients/method/src/POST.cpp
@@ -70,7 +70,6 @@ void POST::generateResource(RequestDts& dts) {
       _content = (*dts.body);
       _title = makeRandomFileName(dts);
       writeTextBody(dts, mimeType);
-      // throw(*dts.statusCode = E_415_UNSUPPORTED_MEDIA_TYPE);
     }
   }
 }
@@ -193,7 +192,7 @@ void POST::writeTextBody(RequestDts& dts, std::string mimeType) {
     filename = *dts.path + _title + "." + mimeType;
   std::ofstream file(filename, std::ios::out);
   if (!file.is_open()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
-  file << _content << "\n";
+  file << _content;
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
   file.close();
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);

--- a/srcs/clients/method/src/PUT.cpp
+++ b/srcs/clients/method/src/PUT.cpp
@@ -27,7 +27,6 @@ void PUT::doRequest(RequestDts& dts, IResponse& response) {
   initUniqueIdandPath(dts);
 
   if (stat(dts.path->c_str(), &fileinfo) < 0) {
-    // generateResource(dts);
     replaceContent(dts);
     response.setStatusCode(E_201_CREATED);
   } else {
@@ -379,7 +378,7 @@ void PUT::writeTextBody(RequestDts& dts) {
     filename = _pathFinder + _uniqueID;
   std::ofstream file(filename.c_str(), std::ios::out);
   if (!file.is_open()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
-  file << _content << "\n";
+  file << _content;
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);
   file.close();
   if (file.fail()) throw((*dts.statusCode) = E_500_INTERNAL_SERVER_ERROR);

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -71,7 +71,6 @@ void EventHandler::checkFlags(void) {
   if (_currentEvent->flags & EV_EOF &&
       Kqueue::getFdType(_currentEvent->ident) == FD_CLIENT) {
     _errorFlag = true;
-    deleteTimerEvent();
     disconnectClient(static_cast<Client *>(_currentEvent->udata));
   }
 }
@@ -200,6 +199,7 @@ void EventHandler::setRequestTimeOutTimer(Client &client) {
  * @param client
  */
 void EventHandler::disconnectClient(Client *client) {
+  deleteTimerEvent();
   deleteEvent((uintptr_t)client->getSD(), EVFILT_WRITE,
               static_cast<void *>(client));
   deleteEvent((uintptr_t)client->getSD(), EVFILT_READ,


### PR DESCRIPTION
- 타이머 이벤트를 EventHandler::disconnectClient 내부에서 무조건 삭제합니다.
- 추가로, POST, PUT에서 text file 생성 시 끝에 들어가는 개행을 삭제했습니다.