### PR TITLE
fix(kqueue): segfault heap use after free memory page

### DIFF
--- a/srcs/server/include/Kqueue.hpp
+++ b/srcs/server/include/Kqueue.hpp
@@ -62,6 +62,7 @@ class Kqueue {
 
  protected:
   static int __kq;
+  static int __new_events_cnt;
   static std::vector<struct kevent> __eventsToAdd;
   static struct kevent __eventList[CONCURRENT_EVENTS];
 
@@ -83,7 +84,7 @@ class Kqueue {
   static void disableEvent(uintptr_t ident, int16_t filter, void* udata);
   static void deleteEvent(uintptr_t ident, int16_t filter, void* udata);
 
-  int newEvents(void);
+  static int newEvents(void);
 
   static e_fd_type getFdType(uintptr_t ident);
   static void setFdSet(uintptr_t ident, e_fd_type type);

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -73,6 +73,10 @@ void EventHandler::checkFlags(void) {
     _errorFlag = true;
     disconnectClient(static_cast<Client *>(_currentEvent->udata));
   }
+  if (_currentEvent->flags & EV_DELETE) {
+    Logger::warningCout("Event Already Delete");
+    _errorFlag = true;
+  }
 }
 
 /**

--- a/srcs/server/src/Kqueue.cpp
+++ b/srcs/server/src/Kqueue.cpp
@@ -16,6 +16,7 @@ fd_set Kqueue::_method_fds;
 fd_set Kqueue::_cgi_fds;
 
 int Kqueue::__kq = 0;
+int Kqueue::__new_events_cnt = 0;
 std::vector<struct kevent> Kqueue::__eventsToAdd = std::vector<struct kevent>();
 struct kevent Kqueue::__eventList[CONCURRENT_EVENTS] = {};
 
@@ -133,6 +134,19 @@ void Kqueue::enableEvent(uintptr_t ident, int16_t filter, void* udata) {
  * 함수가 이벤트를 반환할 때 변경되지 않습니다.
  */
 void Kqueue::deleteEvent(uintptr_t ident, int16_t filter, void* udata) {
+  for (int i = 0; i < Kqueue::__new_events_cnt; i++) {
+    if (Kqueue::__eventList[i].ident == ident &&
+        Kqueue::__eventList[i].filter == filter) {
+      struct kevent& temp_event = Kqueue::__eventList[i];
+      EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, udata);
+      int ret = kevent(Kqueue::__kq, &temp_event, 1, NULL, 0, NULL);
+      if (ret == -1) {
+        Logger::errorCoutNoEndl("Kevent Error On DeleteEvent: ");
+        Logger::errorCoutOnlyMsgWithEndl(ident);
+      };
+      return;
+    }
+  }
   struct kevent temp_event;
   EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, udata);
   int ret = kevent(Kqueue::__kq, &temp_event, 1, NULL, 0, NULL);
@@ -164,6 +178,7 @@ int Kqueue::newEvents() {
                           __eventList, CONCURRENT_EVENTS, NULL);
   if (new_events == -1) Logger::errorCout("kevent error on newEvents");
   __eventsToAdd.clear();
+  Kqueue::__new_events_cnt = new_events;
   return (new_events);
 }
 

--- a/srcs/server/src/Kqueue.cpp
+++ b/srcs/server/src/Kqueue.cpp
@@ -134,6 +134,7 @@ void Kqueue::enableEvent(uintptr_t ident, int16_t filter, void* udata) {
  * 함수가 이벤트를 반환할 때 변경되지 않습니다.
  */
 void Kqueue::deleteEvent(uintptr_t ident, int16_t filter, void* udata) {
+  bool flag = false;
   for (int i = 0; i < Kqueue::__new_events_cnt; i++) {
     if (Kqueue::__eventList[i].ident == ident &&
         Kqueue::__eventList[i].filter == filter) {
@@ -144,9 +145,10 @@ void Kqueue::deleteEvent(uintptr_t ident, int16_t filter, void* udata) {
         Logger::errorCoutNoEndl("Kevent Error On DeleteEvent: ");
         Logger::errorCoutOnlyMsgWithEndl(ident);
       };
-      return;
+      flag = true;
     }
   }
+  if (flag) return;
   struct kevent temp_event;
   EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, udata);
   int ret = kevent(Kqueue::__kq, &temp_event, 1, NULL, 0, NULL);


### PR DESCRIPTION
## 개요
- deleteEvent 호출시 eventList에 해당 이벤트가 존재한다면 레퍼란스와 EV_SET을 활용해 플래그를 설정합니다.
- EventHandler에서 받아온 eventList의 레퍼런스인 currentEvent에서 checkFlag 메소드에서 플래그가 EV_DELETE인지 검증합니다.