### PR TITLE
fix(RequestParser): fix server block matching logic

### DIFF
--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -322,7 +322,6 @@ void RequestParser::matchServerConf(short port, RequestDts &dts) {
   std::list<IServerConfig *>::iterator it = serverInfo.begin();
   std::list<IServerConfig *>::iterator firstServer;
   bool firstFlag = true;
-  if (serverInfo.empty()) throw(42.42);
   while (it != serverInfo.end()) {
     if ((*it)->getListen() != port) {
       ++it;
@@ -339,9 +338,6 @@ void RequestParser::matchServerConf(short port, RequestDts &dts) {
     ++it;
   }
   *dts.matchedServer = *firstServer;
-  if (*dts.matchedServer == NULL) {
-    throw(*dts.statusCode = E_404_NOT_FOUND);
-  }
 }
 
 std::string RequestParser::getFirstTokenOfPath(RequestDts &dts) const {

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -320,19 +320,26 @@ void RequestParser::matchServerConf(short port, RequestDts &dts) {
   Config &config = Config::getInstance();
   std::list<IServerConfig *> serverInfo = config.getServerConfigs();
   std::list<IServerConfig *>::iterator it = serverInfo.begin();
+  std::list<IServerConfig *>::iterator firstServer;
+  bool firstFlag = true;
   if (serverInfo.empty()) throw(42.42);
   while (it != serverInfo.end()) {
     if ((*it)->getListen() != port) {
       ++it;
       continue;
     }
+    if (firstFlag == true) {
+      firstServer = it;
+      firstFlag = false;
+    }
     if ((*it)->getServerName() == (*dts.headerFields)["host"]) {
       *dts.matchedServer = *it;
+      std::cout << (*dts.matchedServer)->getServerName() << '\n';
       return;
     }
-    *dts.matchedServer = *it;
     ++it;
   }
+  *dts.matchedServer = *firstServer;
   if (*dts.matchedServer == NULL) {
     throw(*dts.statusCode = E_404_NOT_FOUND);
   }

--- a/srcs/clients/request/request_parser/src/RequestParser.cpp
+++ b/srcs/clients/request/request_parser/src/RequestParser.cpp
@@ -334,7 +334,6 @@ void RequestParser::matchServerConf(short port, RequestDts &dts) {
     }
     if ((*it)->getServerName() == (*dts.headerFields)["host"]) {
       *dts.matchedServer = *it;
-      std::cout << (*dts.matchedServer)->getServerName() << '\n';
       return;
     }
     ++it;


### PR DESCRIPTION
- 같은 포트로 여러 서버블록이 있을 때 클라이언트가 접속하고자 하는 호스트명 존재하지 않을 경우 해당 포트의 첫 번째 서버로 매칭되도록 로직을 수정하였습니다.