### PR TITLE
fix(server): kqueue deleteEvent and timer

### DIFF
--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -251,6 +251,7 @@ void EventHandler::checkErrorOnSocket() {
  *
  */
 void EventHandler::clientCondition() {
+  if (_currentEvent->udata == 0) return;
   Client &currClient = *(static_cast<Client *>(_currentEvent->udata));
   if (_currentEvent->filter == EVFILT_READ) {
     processRequest(currClient);
@@ -270,6 +271,7 @@ void EventHandler::clientCondition() {
  * filter가 EVFILT_WRITE라면 writeCGI() 함수를 호출합니다.
  */
 void EventHandler::cgiCondition() {
+  if (_currentEvent->udata == 0) return;
   ICGI &cgi = *(static_cast<ICGI *>(_currentEvent->udata));
   if (_currentEvent->filter == EVFILT_READ) {
     cgi.waitAndReadCGI();
@@ -328,7 +330,7 @@ void EventHandler::processRequest(Client &currClient) {
     if (currClient.getState() == RECEIVING) {
       return;
     }
-    deleteTimerEvent();
+    // deleteTimerEvent();
     if (currClient.isCgi()) {
       currClient.makeAndExecuteCgi();
     } else {
@@ -405,6 +407,7 @@ void EventHandler::validateConnection(Client &currClient) {
                 static_cast<void *>(&currClient));
   }
   if (currClient.getState() == END_KEEP_ALIVE) {
+    deleteTimerEvent();
     disableEvent(currClient.getSD(), EVFILT_WRITE,
                  static_cast<void *>(&currClient));
     enableEvent(currClient.getSD(), EVFILT_READ,

--- a/srcs/server/src/Kqueue.cpp
+++ b/srcs/server/src/Kqueue.cpp
@@ -134,12 +134,14 @@ void Kqueue::enableEvent(uintptr_t ident, int16_t filter, void* udata) {
  * 함수가 이벤트를 반환할 때 변경되지 않습니다.
  */
 void Kqueue::deleteEvent(uintptr_t ident, int16_t filter, void* udata) {
+  (void)udata;
   bool flag = false;
   for (int i = 0; i < Kqueue::__new_events_cnt; i++) {
     if (Kqueue::__eventList[i].ident == ident &&
         Kqueue::__eventList[i].filter == filter) {
       struct kevent& temp_event = Kqueue::__eventList[i];
-      EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, udata);
+      temp_event.udata = 0;
+      EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, 0);
       int ret = kevent(Kqueue::__kq, &temp_event, 1, NULL, 0, NULL);
       if (ret == -1) {
         Logger::errorCoutNoEndl("Kevent Error On DeleteEvent: ");
@@ -150,7 +152,7 @@ void Kqueue::deleteEvent(uintptr_t ident, int16_t filter, void* udata) {
   }
   if (flag) return;
   struct kevent temp_event;
-  EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, udata);
+  EV_SET(&temp_event, ident, filter, EV_DELETE, 0, 0, 0);
   int ret = kevent(Kqueue::__kq, &temp_event, 1, NULL, 0, NULL);
   if (ret == -1) {
     Logger::errorCoutNoEndl("Kevent Error On DeleteEvent: ");


### PR DESCRIPTION
## 개요
- delete timer 위치를 평가를 위해 살짝 변경합니다. 서버 타임아웃도 클라이언트 책임으로 위임합니다.
- delete event 를 살짝 보강합니다.