### PR TITLE
refactor(EventHandler): change functions calling position

### DIFF
--- a/srcs/server/include/Kqueue.hpp
+++ b/srcs/server/include/Kqueue.hpp
@@ -9,7 +9,7 @@
 
 #include "Utils.hpp"
 
-#define CONCURRENT_EVENTS 1024
+#define CONCURRENT_EVENTS 64
 
 /**
  * @brief fd type

--- a/srcs/server/src/EventHandler.cpp
+++ b/srcs/server/src/EventHandler.cpp
@@ -187,7 +187,6 @@ void EventHandler::setKeepAliveTimeOutTimer(Client &client) {
 }
 
 void EventHandler::setRequestTimeOutTimer(Client &client) {
-  deleteTimerEvent();
   registEvent(client.getSD(), EVFILT_TIMER, EV_ADD | EV_ONESHOT,
               client.getRequestTimeOutUnit(), client.getRequestTimeOutLimit(),
               static_cast<void *>(&client));


### PR DESCRIPTION
<img width="654" alt="image" src="https://github.com/MyLittleWebServer/webserv/assets/67998022/a36416bf-b2c6-4352-8a9f-0d1407b7faa0">

keep-alive 타임아웃으로 인해 클라이언트와 연결을 해제할 시 뜨는 ERROR 로그가 거슬려서 EventHandler::deleteTimerEvent를 EventHandler::disconnectClient 밖으로 꺼내서, keep-alive 타임아웃으로 인한 disconnectClient를 제외한 모든 disconnectClient호출 전에 deleteTimerEvent를 호출하도록 하였습니다.
이외에, CONCURRENT_EVENTS 값을 64로 변경하여 메인 루프에서 kevent 호출 시 최대 64개의 이벤트를 받아오도록 변경하였습니다.